### PR TITLE
Allow store's source to be overridden

### DIFF
--- a/lib/ember_orbit/store.js
+++ b/lib/ember_orbit/store.js
@@ -20,11 +20,12 @@ function promiseArray(promise, label) {
 }
 
 var Store = Source.extend({
-  orbitSourceClass: OCMemorySource,
+  defaultOrbitSourceClass: OCMemorySource,
   schema: null,
   idField: Ember.computed.alias('schema.idField'),
 
   init: function() {
+    if(!this.orbitSourceClass) this.orbitSourceClass = this.get("defaultOrbitSourceClass");
     this._super.apply(this, arguments);
 
     this.typeMaps = {};


### PR DESCRIPTION
I tried to create a store with using a different source type:

```
var Store = EO.Store.extend({
    orbitSourceClass: OC.LocalStorageSource,
    orbitSourceOptions: {
      namespace: "ember-orbit-todos" // n.s. for localStorage
    }
});
```

But when ember starts up I get an error: Uncaught TypeError: Cannot read property 'apply' of undefined 
which is thrown at https://github.com/orbitjs/orbit.js/blob/master/lib/orbit_common/local_storage_source.js#L24

It appears to have something to do with ember's inheritance as when I removed the default source from property and applied it in the constructor the issue went away. This PR fixes the problem but without knowing exactly what causes the problem I've got a feeling there may be a more elegant way to solve it.
