### PR TITLE
Allow source to be initialized with an instance of an orbit source

### DIFF
--- a/lib/ember_orbit/source.js
+++ b/lib/ember_orbit/source.js
@@ -20,6 +20,19 @@ var Source = Ember.Object.extend({
   init: function() {
     this._super.apply(this, arguments);
 
+    var schema = get(this, 'schema');
+    if (!schema) {
+      var container = get(this, 'container');
+      schema = container.lookup('schema:main');
+      set(this, 'schema', schema);
+    }
+
+    if(!this.orbitSource){
+      this.orbitSource = this._buildOrbitSource(schema);
+    }
+  },
+
+  _buildOrbitSource: function(schema){
     var OrbitSourceClass = get(this, 'orbitSourceClass');
     // If `orbitSourceClass` is obtained through the _super chain, dereference
     // its wrapped function, which will be the constructor.
@@ -29,19 +42,14 @@ var Source = Ember.Object.extend({
     if (OrbitSourceClass && OrbitSourceClass.wrappedFunction) {
       OrbitSourceClass = OrbitSourceClass.wrappedFunction;
     }
+    
     Ember.assert("Source.orbitSourceClass must be initialized with an instance of an `OC.Source`",
       OrbitSourceClass instanceof OCSource);
 
-    var schema = get(this, 'schema');
-    if (!schema) {
-      var container = get(this, 'container');
-      schema = container.lookup('schema:main');
-      set(this, 'schema', schema);
-    }
-
     var orbitSourceSchema = get(schema, '_schema');
     var orbitSourceOptions = get(this, 'orbitSourceOptions');
-    this.orbitSource = new OrbitSourceClass(orbitSourceSchema, orbitSourceOptions);
+
+    return new OrbitSourceClass(orbitSourceSchema, orbitSourceOptions); 
   }
 });
 

--- a/test/tests/unit/source_test.js
+++ b/test/tests/unit/source_test.js
@@ -4,6 +4,9 @@ import Schema from 'ember_orbit/schema';
 import OCMemorySource from 'orbit_common/memory_source';
 import OCLocalStorageSource from 'orbit_common/local_storage_source';
 
+var get = Ember.get,
+    set = Ember.set;
+
 var source;
 
 module("Unit - Source", {
@@ -42,4 +45,23 @@ test("it can specify a custom `orbitSourceClass` and `orbitSourceOptions`", func
   ok(customSource, 'custom source exists');
   ok(customSource.orbitSource instanceof OCLocalStorageSource, 'custom source has the right type of `orbitSource`');
   equal(customSource.orbitSource.namespace, 'custom', 'custom source has the right custom namespace');
+});
+
+test("it can specify a custom `orbitSource`", function() {
+  expect(2);
+
+
+  var schema = Schema.create();
+  var orbitSource = new OCMemorySource(get(schema, "_schema"), {});
+  var CustomSource = Source.extend({
+    orbitSource: orbitSource
+  });
+
+  var customSource = CustomSource.create({
+    container: new Ember.Container(),
+    schema: schema
+  });
+
+  ok(customSource, 'custom source exists');
+  ok(customSource.orbitSource instanceof OCMemorySource, 'custom source has the right type of `orbitSource`');
 });


### PR DESCRIPTION
Currently you can only initialize a source/store by specifying the class of the orbit source e.g. 

	var LocalStorageStore = EO.Store.extend({
	  	orbitSourceClass: OC.LocalStorageSource,
	  	orbitSourceOptions: {
		  namespace: "ember-orbit-todos" // n.s. for localStorage
		}
	});

This PR allows the source/store to be initialised with an instance e.g.

	var schema = Schema.create();	 
	var orbitSource = new OCMemorySource(get(schema, "_schema"), {}); 

	var LocalStorageStore = EO.Store.extend({
	  	orbitSource: orbitSource;
	});