### PR TITLE
Convert to Ember CLI addon.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,21 @@ Ember-Orbit.
 
 ## Installation
 
-For now it is necessary to build Ember-Orbit from source. See instructions
-below.
+Install as an Ember CLI addon:
 
+```
+npm install orbit/ember-orbit --save
+```
+
+You'll need to add the following to your project's environment.js file:
+
+```
+ORBIT: {
+  IMPORTS: ['orbit.js', 'orbit-common.js', 'orbit-common-jsonapi.js', 'orbit-common-local-storage.js']
+}
+```
+
+Customize this to include the Orbit files you need.
 
 ## Building and Testing Ember-Orbit
 

--- a/lib/ember-addon.js
+++ b/lib/ember-addon.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var path       = require('path');
+var fs         = require('fs');
+var pickFiles  = require('broccoli-static-compiler');
+var mergeTrees = require('broccoli-merge-trees');
+var _          = require('underscore');
+
+function EmberCLIEmberOrbit(project) {
+  this.project = project;
+  this.name    = 'Ember CLI Ember Orbit';
+}
+
+function unwatchedTree(dir) {
+  return {
+    read:    function() { return dir; },
+    cleanup: function() { }
+  };
+}
+
+EmberCLIEmberOrbit.prototype.treeFor = function treeFor(name) {
+  if (name === 'vendor') {
+    var distPath = path.join(__dirname, '..', 'dist');
+    var dist = pickFiles(distPath, {
+      srcDir: '/',
+      files: ['ember-orbit.js'],
+      destDir: '/'
+    });
+
+    var orbitPath = path.join(__dirname, '..', 'bower_components', 'orbit.js');
+    var orbit = pickFiles(orbitPath, {
+      srcDir: '/',
+      files: ['orbit.js', 'orbit-common.js', 'orbit-common-jsonapi.js', 'orbit-common-local-storage.js'],
+      destDir: '/'
+    });
+
+    return mergeTrees([dist, orbit]);
+  }
+};
+
+EmberCLIEmberOrbit.prototype.included = function included(app) {
+  this.app = app;
+
+  var imports = app.options.getEnvJSON(this.app.env).ORBIT.IMPORTS;
+
+  _.each(imports, function(imp) {
+    app.import('vendor/' + imp);
+  });
+
+  app.import('vendor/ember-orbit.js');
+};
+
+module.exports = EmberCLIEmberOrbit;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,12 @@
     "name": "Cerebris Corporation",
     "url": "http://cerebris.com"
   },
+  "keywords": [
+    "ember-addon"
+  ],
+  "ember-addon": {
+    "main": "lib/ember-addon"
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/cerebris/ember-orbit.git"
@@ -42,9 +48,8 @@
     "grunt-contrib-connect": "~0.6.0",
     "grunt-contrib-copy": "~0.5.0",
     "grunt-contrib-jshint": "~0.8.0",
-    "grunt-contrib-uglify": "~0.3.2",
-    "grunt-contrib-watch": "~0.5.3",
     "grunt-contrib-uglify": "~0.2.4",
+    "grunt-contrib-watch": "~0.5.3",
     "grunt-contrib-yuidoc": "~0.5.0",
     "grunt-es6-module-transpiler": "~0.4.0",
     "grunt-usemin": "~2.0.2",
@@ -57,5 +62,10 @@
     "load-grunt-config": "~0.5.0",
     "load-grunt-tasks": "~0.2.0",
     "string": "~1.8.0"
+  },
+  "dependencies": {
+    "broccoli-merge-trees": "^0.1.4",
+    "broccoli-static-compiler": "^0.1.4",
+    "underscore": "^1.6.0"
   }
 }


### PR DESCRIPTION
Fixes #8. I've converted this into an Ember CLI addon. I've made it to where you can specify which orbit files you want included in your environment.js file. I've updated the README but it the install instructions won't fully work until my pull request is accepted. Further, the instructions will change when it goes on npm.