### PR TITLE
Register linked type models.

### DIFF
--- a/lib/ember-orbit/store.js
+++ b/lib/ember-orbit/store.js
@@ -168,6 +168,7 @@ var Store = Source.extend({
     this._verifyType(type);
 
     var linkType = get(this, 'schema').linkProperties(type, key).model;
+    this._verifyType(linkType);
 
     var promise = this.orbitSource.findLink(type, id, key).then(function(data) {
       return _this._lookupFromData(linkType, data);
@@ -211,6 +212,7 @@ var Store = Source.extend({
     this._verifyType(type);
 
     var linkType = get(this, 'schema').linkProperties(type, key).model;
+    this._verifyType(linkType);
 
     var relatedId = this.orbitSource.retrieve([type, id, '__rel', key]);
 
@@ -223,6 +225,7 @@ var Store = Source.extend({
     this._verifyType(type);
 
     var linkType = get(this, 'schema').linkProperties(type, key).model;
+    this._verifyType(linkType);
 
     var relatedIds = Object.keys(this.orbitSource.retrieve([type, id, '__rel', key]));
 


### PR DESCRIPTION
This change was necessary to make "findLink" work on models that have not been requested directly before .
