### PR TITLE
Makes it possible to remove a "hasone" link by setting it to null or undefined.

### DIFF
--- a/lib/ember-orbit/fields/has-one.js
+++ b/lib/ember-orbit/fields/has-one.js
@@ -19,7 +19,11 @@ var hasOne = function(model, options) {
     var proxy = this.getLink(key);
 
     if (arguments.length > 1) {
-      if (value !== get(proxy, 'content')) {
+      if('undefined' === typeof(value) || value===null){
+        proxy.setProperties({
+          promise: this.removeLink(key, get(proxy, 'content'))
+        });
+      }else if (value !== get(proxy, 'content')) {
         proxy.setProperties({
           content: value,
           promise: this.addLink(key, value)


### PR DESCRIPTION
For instance, you can now do something like this : 

``` javascript
moon.set("planet",null)
```
