### PR TITLE
Use OrderedSet#delete instead of (deprecated) OrderedSet#remove

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,10 +2,10 @@
   "name": "ember-orbit",
   "private": true,
   "dependencies": {
-    "handlebars": "~1.1.2",
-    "jquery": "~1.9.1",
-    "qunit": "~1.12.0",
-    "ember": ">= 1.7.0",
+    "handlebars": ">= 2.0.0 < 3.0.0",
+    "jquery": "~1.10.2",
+    "qunit": "~1.15.0",
+    "ember": ">= 1.9.1",
     "orbit.js": ">= 0.5.3"
   }
 }

--- a/lib/ember-orbit/record-arrays/record-array.js
+++ b/lib/ember-orbit/record-arrays/record-array.js
@@ -68,7 +68,7 @@ var RecordArray = Ember.ArrayProxy.extend(Ember.Evented, {
   },
 
   _recordRemoved: function(record) {
-    this._recordArraysForRecord(record).remove(this);
+    this._recordArraysForRecord(record).delete(this);
   },
 
   _recordsAdded: function(records) {

--- a/lib/ember-orbit/store.js
+++ b/lib/ember-orbit/store.js
@@ -343,7 +343,7 @@ var Store = Source.extend({
     var requests = this._requests;
     requests.add(promise);
     return promise.finally(function() {
-      requests.remove(promise);
+      requests.delete(promise);
     });
   },
 


### PR DESCRIPTION
Not sure if you will need this just yet, I'm using ember-orbit with Ember.js canary and noticed a deprecation warning so figured I'd create an issue and pr to track it here.

See: https://github.com/emberjs/ember.js/commit/39bf8b23a8482eb9fffeda00d8beb914c3b8c444 build channel v1.9.0-alpha

[Fixes #42]