### PR TITLE
Change to ember.assert syntax to make it work with Ember Canary.

### DIFF
--- a/lib/ember-orbit/store.js
+++ b/lib/ember-orbit/store.js
@@ -273,7 +273,10 @@ var Store = Source.extend({
   },
 
   _verifyType: function(type) {
-    Ember.assert("`type` must be registered as a model in the container", get(this, 'schema').modelFor(type));
+    var _this = this;
+    Ember.assert("`type` must be registered as a model in the container", function verifyType(){
+     return get(_this, 'schema').modelFor(type);
+    });
   },
 
   _didTransform: function(operation, inverse) {

--- a/lib/ember-orbit/store.js
+++ b/lib/ember-orbit/store.js
@@ -273,10 +273,7 @@ var Store = Source.extend({
   },
 
   _verifyType: function(type) {
-    var _this = this;
-    Ember.assert("`type` must be registered as a model in the container", function verifyType(){
-     return get(_this, 'schema').modelFor(type);
-    });
+    Ember.assert("`type` must be registered as a model in the container", 'function' === typeof get(this, 'schema').modelFor(type));
   },
 
   _didTransform: function(operation, inverse) {


### PR DESCRIPTION
A very small change to make ember-orbit work with Ember Canary. (Cf https://github.com/emberjs/ember.js/commit/2daec0b758593083041a80c037e5996219480dcf)