### PR TITLE
Add support for actsAsOrderedSet

### DIFF
--- a/lib/ember-orbit/links/has-many-array.js
+++ b/lib/ember-orbit/links/has-many-array.js
@@ -31,7 +31,7 @@ var HasManyArray = RecordArray.extend(LinkProxyMixin, {
     for (var i = index; i < index + removed; i++) {
       record = content.objectAt(i);
       recordId = record.primaryId;
-      store.removeLink(ownerType, ownerId, linkField, recordId);
+      store.removeLink(ownerType, ownerId, linkField, recordId, index);
     }
 
     return this._super.apply(this, arguments);
@@ -50,7 +50,7 @@ var HasManyArray = RecordArray.extend(LinkProxyMixin, {
     for (var i = index; i < index + added; i++) {
       record = content.objectAt(i);
       recordId = record.primaryId;
-      store.addLink(ownerType, ownerId, linkField, recordId);
+      store.addLink(ownerType, ownerId, linkField, recordId, index);
     }
   }
 

--- a/lib/ember-orbit/record-array-manager.js
+++ b/lib/ember-orbit/record-array-manager.js
@@ -47,7 +47,9 @@ var RecordArrayManager = Ember.Object.extend({
 
     var path = operation.path,
         op = operation.op,
-        value = operation.value;
+        value = operation.value,
+        linkProperties,
+        store;
 
     if (path.length === 2) {
       if (op === 'add') {
@@ -64,7 +66,14 @@ var RecordArrayManager = Ember.Object.extend({
       return;
 
     } else if (path.length === 5) {
-      if (op === 'add') {
+      store = get(this, 'store');
+      linkProperties = get(store, 'schema').linkProperties(path[0], path[3]);
+
+      if (op === 'add' && linkProperties.actsAsOrderedSet){
+        this._linkWasAdded(record, path[3], value, path[4]);
+        return;
+
+      } else if (op === 'add') {
         this._linkWasAdded(record, path[3], path[4]);
         return;
 
@@ -104,7 +113,7 @@ var RecordArrayManager = Ember.Object.extend({
     }
   },
 
-  _linkWasAdded: function(record, key, value) {
+  _linkWasAdded: function(record, key, value, index) {
     var type = record.constructor.typeKey;
     var store = get(this, 'store');
     var linkType = get(store, 'schema').linkProperties(type, key).model;
@@ -114,7 +123,12 @@ var RecordArrayManager = Ember.Object.extend({
       var links = get(record, key);
 
       if (links && relatedRecord) {
-        links.addObject(relatedRecord);
+        if(index) {
+          links.insertAt(index, relatedRecord);
+        }
+        else {
+          links.addObject(relatedRecord);
+        }
       }
     }
   },

--- a/lib/ember-orbit/record-arrays/record-array.js
+++ b/lib/ember-orbit/record-arrays/record-array.js
@@ -52,6 +52,23 @@ var RecordArray = Ember.ArrayProxy.extend(Ember.Evented, {
     this._recordAdded(record);
   },
 
+  insertAt: function(index, record) {
+    var content = get(this, 'content');
+
+    var resolvedIndex = index === "-" ? content.length : index;
+
+    if(content.objectAt(resolvedIndex) === record) return;
+    if(index === '-' && content.get("lastObject") === record) return;
+
+
+    if(content.contains(record)){
+      this.removeObject(record);
+    }
+
+    content.insertAt(resolvedIndex, record);
+    this._recordAdded(record);
+  },
+
   /**
    Removes a record from the `RecordArray`.
 

--- a/lib/ember-orbit/schema.js
+++ b/lib/ember-orbit/schema.js
@@ -140,6 +140,7 @@ var Schema = Ember.Object.extend({
   normalize: function(type, record) {
     // Normalize links to IDs contained within the `__rel` (i.e. "forward link")
     // element.
+    var _this = this;
     this.links(type).forEach(function(link) {
       if (!record.__rel) {
         record.__rel = {};
@@ -148,13 +149,18 @@ var Schema = Ember.Object.extend({
       var linkValue = record[link];
       if (linkValue) {
         if (Ember.isArray(linkValue)) {
-          var rel = record.__rel[link] = {};
-          linkValue.forEach(function(id) {
-            if (typeof id === 'object') {
-              id = id.primaryId;
-            }
-            rel[id] = true;
-          });
+          if(_this.linkProperties(type, link).actsAsOrderedSet){
+            record.__rel[link] = linkValue;
+          }
+          else {
+            var rel = record.__rel[link] = {};
+            linkValue.forEach(function(id) {
+              if (typeof id === 'object') {
+                id = id.primaryId;
+              }
+              rel[id] = true;
+            });
+          }
 
         } else if (typeof linkValue === 'object') {
           record.__rel[link] = linkValue.primaryId;

--- a/lib/ember-orbit/store.js
+++ b/lib/ember-orbit/store.js
@@ -124,6 +124,7 @@ var Store = Source.extend({
     properties = properties || {};
 
     get(this, 'schema').normalize(type, properties);
+
     var promise = this.orbitSource.add(type, properties).then(function(data) {
       return _this._lookupFromData(type, data);
     });
@@ -149,22 +150,22 @@ var Store = Source.extend({
     return this._request(promise);
   },
 
-  addLink: function(type, id, field, relatedId) {
+  addLink: function(type, id, field, relatedId, index) {
     this._verifyType(type);
     id = this._normalizeId(id);
     relatedId = this._normalizeId(relatedId);
 
-    var promise = this.orbitSource.addLink(type, id, field, relatedId);
+    var promise = this.orbitSource.addLink(type, id, field, relatedId, index);
 
     return this._request(promise);
   },
 
-  removeLink: function(type, id, field, relatedId) {
+  removeLink: function(type, id, field, relatedId, index) {
     this._verifyType(type);
     id = this._normalizeId(id);
     relatedId = this._normalizeId(relatedId);
 
-    var promise = this.orbitSource.removeLink(type, id, field, relatedId);
+    var promise = this.orbitSource.removeLink(type, id, field, relatedId, index);
 
     return this._request(promise);
   },
@@ -254,10 +255,14 @@ var Store = Source.extend({
     this._verifyType(type);
     id = this._normalizeId(id);
 
-    var linkType = get(this, 'schema').linkProperties(type, field).model;
+    var linkDef = get(this, 'schema').linkProperties(type, field);
+    var linkType = linkDef.model;
     this._verifyType(linkType);
 
-    var relatedIds = Object.keys(this.orbitSource.retrieve([type, id, '__rel', field]));
+    var fieldValue = this.orbitSource.retrieve([type, id, '__rel', field]);
+    if(!fieldValue) return linkDef.type === "hasMany" ? [] : null;
+
+    var relatedIds = Ember.isArray(fieldValue) ? fieldValue : Object.keys(fieldValue);
 
     if (linkType && Ember.isArray(relatedIds) && relatedIds.length > 0) {
       return this.retrieve(linkType, relatedIds);
@@ -277,22 +282,26 @@ var Store = Source.extend({
   },
 
   _didTransform: function(operation, inverse) {
-//    console.log('_didTransform', operation, inverse);
-
+    // console.log("store._didTransform", [operation.op, operation.path.join("/"), operation.value].join(" "));
     var op = operation.op,
         path = operation.path,
         value = operation.value,
         record = this._lookupRecord(path[0], path[1]);
-
+        
     if (path.length === 3) {
       // attribute changed
       record.propertyDidChange(path[2]);
 
     } else if (path.length === 4) {
-      // hasOne link changed
-      var linkName = path[3];
-      var linkValue = this.retrieveLink(path[0], path[1], linkName);
-      record.set(linkName, linkValue);
+      var linkProperties = get(this, 'schema').linkProperties(path[0], path[3]);
+
+      if(linkProperties.type === "hasOne"){
+        // hasOne link changed
+        var linkName = path[3];
+        var linkValue = this.retrieveLink(path[0], path[1], linkName);
+        record.set(linkName, linkValue);
+      }
+
     }
 
     // trigger record array changes


### PR DESCRIPTION
This goes along with https://github.com/orbitjs/orbit.js/pull/84 to add support for the actsAsOrderedSet option on hasMany relations.