### PR TITLE
Proposal - Add lifecycle hooks

### DIFF
--- a/lib/ember-orbit/store.js
+++ b/lib/ember-orbit/store.js
@@ -22,6 +22,8 @@ function promiseArray(promise, label) {
 var Store = Source.extend({
   orbitSourceClass: OCMemorySource,
   schema: null,
+  listeners: null,
+  _callbackActions: ['add'],
 
   init: function() {
     this._super.apply(this, arguments);
@@ -34,6 +36,40 @@ var Store = Source.extend({
 
     this._recordArrayManager = RecordArrayManager.create({
       store: this
+    });
+
+    this._initListeners();
+  },
+
+  _initListeners: function(){
+    var _this = this;
+    this.listeners = this.listeners || [];
+
+    this.get('_callbackActions').forEach(function(callbackAction){
+      
+      var originalAction = _this[callbackAction];
+
+      _this[callbackAction] = function(){
+        var callArguments = Array.prototype.slice.apply(arguments);
+        _this._notifyListeners('before' + callbackAction.capitalize(), callArguments);
+
+        return originalAction.apply(_this, arguments).then(function(result){
+          _this._notifyListeners('after' + callbackAction.capitalize(), callArguments.concat([result]));
+          return result;
+
+        }, function(error){
+          _this._notifyListeners(callbackAction + "Rejected", callArguments.concat([error]));
+          throw error;
+        });
+      };
+    });    
+  },
+
+  _notifyListeners: function(event, args){
+    var triggerArgs = [event].concat(args.slice(0));
+    console.log(event, triggerArgs);
+    this.listeners.forEach(function(listener){
+      listener.trigger.apply(listener, triggerArgs);
     });
   },
 

--- a/test/tests/integration/lifecycle-callbacks-test.js
+++ b/test/tests/integration/lifecycle-callbacks-test.js
@@ -1,0 +1,123 @@
+import Schema from 'ember-orbit/schema';
+import Store from 'ember-orbit/store';
+import Model from 'ember-orbit/model';
+import attr from 'ember-orbit/fields/attr';
+import hasOne from 'ember-orbit/fields/has-one';
+import hasMany from 'ember-orbit/fields/has-many';
+import { createStore } from 'tests/test-helper';
+import Orbit from 'orbit/main';
+
+var get = Ember.get,
+    set = Ember.set;
+
+var orbitListenerStub,
+	store;
+
+module("Integration - lifecycle callbacks", {
+	setup: function(){
+		var Star,
+			Moon,
+			Planet;
+
+		Orbit.Promise = Ember.RSVP.Promise;
+
+		Planet = Model.extend({
+			name: attr('string'),
+			atmosphere: attr('boolean'),
+			classification: attr('string'),
+			sun: hasOne('star'),
+			moons: hasMany('moon')
+		});
+
+		Moon = Model.extend({
+			name: attr('string'),
+			planet: hasOne('planet')
+		});
+
+		Star = Model.extend({
+			name: attr('string'),
+			planets: hasMany('planet')
+		});
+
+		orbitListenerStub = Ember.Object.extend(Ember.Evented, {
+			onBeforeAdd: function(type, properties){
+				console.log("onBeforeAdd", arguments);
+				this.beforeAdd(type, properties);
+			}.on("beforeAdd"),
+
+			onAfterAdd: function(type, properties, result){
+				this.afterAdd(type, properties, result);
+			}.on("afterAdd"),			
+
+			onAddRejected: function(type, properties, error){
+				this.addRejected(type, properties, error);
+			}.on("addRejected"),
+
+			beforeAdd: sinon.spy(),
+			afterAdd: sinon.spy(),
+			addRejected: sinon.spy(),
+		}).create();
+
+		var LifecycleStore = Store.extend({
+			listeners: [orbitListenerStub]
+		});
+
+		var container = new Ember.Container();
+		container.register('schema:main', Schema);
+		container.register('store:main', LifecycleStore);
+
+		var models = {
+			planet: Planet,
+			moon: Moon,
+			star: Star
+		};
+
+		if (models) {
+			for (var prop in models) {
+				container.register('model:' + prop, models[prop]);
+			}
+		}
+
+		store = container.lookup('store:main');		
+	}
+});
+
+test("beforeAdd is called before store.add", function(){
+	stop();
+	var earth = {name: 'Earth'};
+	store.add('planet', earth).then(function() {
+		start();
+		ok(orbitListenerStub.beforeAdd.calledWith('planet', earth));
+	});
+});
+
+test("afterAdd is called after store.add", function(){
+	stop();
+	var earth = {name: 'Earth'};
+	store.add('planet', earth).then(function(planet) {
+		start();
+
+		var callArgs = orbitListenerStub.afterAdd.getCall(0).args;
+		equal(callArgs[0], 'planet');
+		equal(callArgs[1], earth);
+		equal(callArgs[2].get("name"), "Earth");
+	});
+});
+
+test("addRejected is called when store.add is rejected", function(){
+	stop();
+
+	var earth = {name: 'Earth'};
+	store.orbitSource.add = function(){
+		return Ember.RSVP.reject("add rejected");
+	};
+
+	store.add('planet', earth).catch(function() {
+		start();
+
+		var callArgs = orbitListenerStub.addRejected.getCall(0).args;
+		equal(callArgs[0], 'planet');
+		equal(callArgs[1], earth);
+		equal(callArgs[2], "add rejected");
+	});
+});

--- a/test/tests/test-helper.js
+++ b/test/tests/test-helper.js
@@ -7,7 +7,7 @@ var get = Ember.get,
 var createStore = function(options) {
   options = options || {};
 
-  var container = new Ember.Container();
+  var container = options.container || new Ember.Container();
   container.register('schema:main', Schema);
   container.register('store:main', Store);
 


### PR DESCRIPTION
This is a sketch of how lifecycle hooks might work. 

When various operations (e.g. add/remove) are called on the store, listeners are notified e.g.
    
    var listener = Ember.Object.extend(Ember.Evented, {
        beforeAdd: function(type, properties){
            // ...
        }.on("beforeAdd")

        afterAdd: function(type, properties, newRecord){
            // ...
        }.on("afterAdd"),

        addRejected: function(type, properties, error){
            // ...
        }.on("addRejected")
    });

    var ListenersStore = Store.extend({
        listeners: [listener]
    });

    var store = ListenersStore.create(...);

    store.add('user', userProperties); // triggers beforeAdd, afterAdd or addRejected on error

For each operation on store for which listeners are enabled three events may be fired e.g. beforeAdd, afterAdd, addRejected . The parameters match the signature for the method on the store with the exception that the after hook includes the result and the rejected hook includes the error.

Things to consider:

1) Which store methods should be included - probably add, remove, addLink, removeLink
2) How should listeners be registered? Perhaps they should be stored in project_root/orbit-listeners 
3) Should listeners be registered in ember's container to allow injection of services?
