### PR TITLE
Move from deprecated values property

### DIFF
--- a/lib/ember-orbit/record-array-manager.js
+++ b/lib/ember-orbit/record-array-manager.js
@@ -231,7 +231,12 @@ var RecordArrayManager = Ember.Object.extend({
   willDestroy: function(){
     this._super();
 
-    flatten(values(this.filteredRecordArrays.values)).forEach(destroy);
+    var filteredRecordArraysValues = [];
+    this.filteredRecordArrays.forEach(function(value) {
+      filteredRecordArraysValues.push(value);
+    });
+
+    flatten(values(filteredRecordArraysValues)).forEach(destroy);
   }
 });
 
@@ -242,7 +247,6 @@ function values(obj) {
   for (var i = 0; i < keys.length; i++) {
     result.push(obj[keys[i]]);
   }
-
   return result;
 }
 

--- a/test/tests/unit/record-array-manager-test.js
+++ b/test/tests/unit/record-array-manager-test.js
@@ -1,0 +1,34 @@
+import Orbit from 'orbit';
+import RecordArrayManager from 'ember-orbit/record-array-manager';
+
+var get = Ember.get;
+
+var jupiter,
+    recordArrayManager;
+
+module('Unit - RecordArrayManager', {
+  setup: function() {
+    jupiter = {name: 'Jupiter', destroy: sinon.spy()};
+    recordArrayManager = RecordArrayManager.create({});
+  },
+
+  teardown: function() {
+    jupiter = null;
+    recordArrayManager = null;
+  }
+});
+
+test('#willDestroy destroys objects in filterRecordArrays', function() {
+  recordArrayManager.filteredRecordArrays.get('planet').push(jupiter);
+  recordArrayManager.willDestroy();
+  ok(jupiter.destroy.called);
+});
+
+test('#willDestroy with no filterRecordArrays values, completes w/o error', function() {
+  try {
+    recordArrayManager.willDestroy();
+    ok('passed');
+  } catch(exception) {
+    ok(false, 'willDestroy throws: ' + exception);
+  }
+});


### PR DESCRIPTION
* instead collect values with forEach which works both in 1.10 & 1.11.0-beta5

Calling this.filteredRecordArray.values was returning undefined against Ember 1.11.0-beta5.