### PR TITLE
Use ember accessors to prevent 'undefined' primaryId

### DIFF
--- a/lib/ember-orbit/schema.js
+++ b/lib/ember-orbit/schema.js
@@ -151,13 +151,13 @@ var Schema = Ember.Object.extend({
           var rel = record.__rel[link] = {};
           linkValue.forEach(function(id) {
             if (typeof id === 'object') {
-              id = id.primaryId;
+              id = get(id, 'primaryId');
             }
             rel[id] = true;
           });
 
         } else if (typeof linkValue === 'object') {
-          record.__rel[link] = linkValue.primaryId;
+          record.__rel[link] = get(linkValue, 'primaryId');
 
         } else {
           record.__rel[link] = linkValue;


### PR DESCRIPTION
Been seeing a bug where objects sometimes don't have their primaryId available unless you use object.get('primaryId'). As we can assume the objects are ember objects using a getter seems appropriate.