### PR TITLE
Add lifecycle hooks

### DIFF
--- a/autobuild
+++ b/autobuild
@@ -1,0 +1,2 @@
+./builder
+fswatch-run lib test ./builder

--- a/builder
+++ b/builder
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+npm run build
+terminal-notifier -message "Built ember-orbit"

--- a/lib/ember-orbit/store.js
+++ b/lib/ember-orbit/store.js
@@ -115,11 +115,11 @@ var Store = Source.extend({
     }, null, "OE: Store#filter of " + type));
   },
 
-  find: function(type, id) {
+  find: function(type, id, options) {
     var _this = this;
     this._verifyType(type);
 
-    var promise = this.orbitSource.find(type, id).then(function(data) {
+    var promise = this.orbitSource.find(type, id, options).then(function(data) {
       return _this._lookupFromData(type, data);
     });
 
@@ -192,7 +192,7 @@ var Store = Source.extend({
     return this._request(promise);
   },
 
-  findLinked: function(type, id, field) {
+  findLinked: function(type, id, field, options) {
     var _this = this;
     this._verifyType(type);
     id = this._normalizeId(id);
@@ -200,7 +200,7 @@ var Store = Source.extend({
     var linkType = get(this, 'schema').linkProperties(type, field).model;
     this._verifyType(linkType);
 
-    var promise = this.orbitSource.findLinked(type, id, field).then(function(data) {
+    var promise = this.orbitSource.findLinked(type, id, field, options).then(function(data) {
       return _this._lookupFromData(linkType, data);
     });
 

--- a/lib/ember-orbit/store.js
+++ b/lib/ember-orbit/store.js
@@ -37,6 +37,11 @@ var Store = Source.extend({
     });
   },
 
+  _fireHook: function(type, event, hookArguments){
+    var observer = this.container.lookup("observer:" + type);
+    if(observer) observer.trigger.apply(observer, [event].concat(hookArguments));
+  },
+
   then: function(success, failure) {
     return this.settleRequests().then(success, failure);
   },
@@ -136,45 +141,68 @@ var Store = Source.extend({
       return _this._lookupFromData(type, data);
     });
 
-    return this._request(promise);
+    return this._request(promise).then(function(record){
+      _this._fireHook(type, 'afterAddRecord', [record]);
+      return record;
+    });
   },
 
   remove: function(type, id) {
+    var _this = this;
     this._verifyType(type);
     id = this._normalizeId(id);
 
+    var record = this._lookupRecord(type, id);
     var promise = this.orbitSource.remove(type, id);
 
-    return this._request(promise);
+    return this._request(promise).then(function(){
+      _this._fireHook(type, 'afterRemoveRecord', [record]);
+    });
   },
 
   patch: function(type, id, field, value) {
+    var _this = this;
     this._verifyType(type);
     id = this._normalizeId(id);
 
     var promise = this.orbitSource.patch(type, id, field, value);
 
-    return this._request(promise);
+    return this._request(promise).then(function(){
+      var record = _this._lookupRecord(type, id);
+      _this._fireHook(type, 'afterPatchRecord', [record, field, value]);
+    });
   },
 
   addLink: function(type, id, field, relatedId) {
+    var _this = this;
     this._verifyType(type);
     id = this._normalizeId(id);
     relatedId = this._normalizeId(relatedId);
 
     var promise = this.orbitSource.addLink(type, id, field, relatedId);
 
-    return this._request(promise);
+    return this._request(promise).then(function(){
+      var record = _this._lookupRecord(type, id);
+      var linkType = _this.schema.linkProperties(type, field).model;
+      var value = _this._lookupRecord(linkType, relatedId);
+      _this._fireHook(type, 'afterAddLink', [record, field, value]);
+    });
   },
 
   removeLink: function(type, id, field, relatedId) {
+    var _this = this;
     this._verifyType(type);
     id = this._normalizeId(id);
     relatedId = this._normalizeId(relatedId);
 
     var promise = this.orbitSource.removeLink(type, id, field, relatedId);
 
-    return this._request(promise);
+    return this._request(promise).then(function(){
+      var record = _this._lookupRecord(type, id);
+      var linkType = _this.schema.linkProperties(type, field).model;
+      var value = _this._lookupRecord(linkType, relatedId);
+      _this._fireHook(type, 'afterRemoveLink', [record, field, value]);
+    });
   },
 
   findLink: function(type, id, field) {
@@ -287,7 +315,7 @@ var Store = Source.extend({
   },
 
   _didTransform: function(operation, inverse) {
-//    console.log('_didTransform', operation, inverse);
+   // console.log('_didTransform', operation.serialize());
 
     var op = operation.op,
         path = operation.path,

--- a/lib/ember-orbit/store.js
+++ b/lib/ember-orbit/store.js
@@ -265,7 +265,9 @@ var Store = Source.extend({
     var linkType = get(this, 'schema').linkProperties(type, field).model;
     this._verifyType(linkType);
 
-    var relatedIds = Object.keys(this.orbitSource.retrieve([type, id, '__rel', field]));
+    var links = this.orbitSource.retrieve([type, id, '__rel', field]);
+    if(links === undefined) throw new Error("Link " + [type,id,field].join("/") + " is not loaded. Add it to your includes e.g. find('" + type + "', '" + id + "', {include: ['" + field + "']})");
+    var relatedIds = Object.keys(links);
 
     if (linkType && Ember.isArray(relatedIds) && relatedIds.length > 0) {
       return this.retrieve(linkType, relatedIds);

--- a/test/tests/integration/store-hooks-test.js
+++ b/test/tests/integration/store-hooks-test.js
@@ -1,0 +1,231 @@
+import Orbit from 'orbit';
+import OCLocalStorageSource from 'orbit-common/local-storage-source';
+import { RecordNotFoundException, RecordAlreadyExistsException } from 'orbit-common/lib/exceptions';
+import attr from 'ember-orbit/fields/attr';
+import hasOne from 'ember-orbit/fields/has-one';
+import hasMany from 'ember-orbit/fields/has-many';
+import Store from 'ember-orbit/store';
+import Model from 'ember-orbit/model';
+import Schema from 'ember-orbit/schema';
+import { createStore } from 'tests/test-helper';
+import { spread } from 'orbit/lib/functions';
+
+var get = Ember.get,
+    set = Ember.set;
+
+var Planet,
+    Moon,
+    Star,
+    store,
+    planetObserver;
+
+var PlanetObserver = Ember.Object.extend(Ember.Evented, {
+  initialize: function(){
+    this.afterAddRecord = sinon.spy();
+    this.afterRemoveRecord = sinon.spy();
+    this.afterPatchRecord = sinon.spy();
+    this.afterAddLink = sinon.spy();
+    this.afterRemoveLink = sinon.spy();
+  }.on('init'),
+
+  afterAddRecordListener: function(){
+    this.afterAddRecord.apply(this, arguments);
+  }.on('afterAddRecord'),
+
+  afterRemoveRecordListener: function(){
+    this.afterRemoveRecord.apply(this, arguments);
+  }.on('afterRemoveRecord'),
+
+  afterPatchRecordListener: function(){
+    this.afterPatchRecord.apply(this, arguments);
+  }.on('afterPatchRecord'),
+
+  afterAddLinkListener: function(){
+    this.afterAddLink.apply(this, arguments);
+  }.on('afterAddLink'),
+
+  afterRemoveLinkListener: function(){
+    this.afterRemoveLink.apply(this, arguments);
+  }.on('afterRemoveLink')
+});
+
+module("Unit - Store - hooks", {
+  setup: function() {
+    Orbit.Promise = Ember.RSVP.Promise;
+
+    Planet = Model.extend({
+      name: attr('string'),
+      atmosphere: attr('boolean'),
+      classification: attr('string'),
+      moons: hasMany('moon'),
+      sun: hasOne('star')
+    });
+
+    Moon = Model.extend({
+      name: attr('string'),
+      planet: hasOne('planet')
+    });
+
+    Star = Model.extend({
+      name: attr('string'),
+      planets: hasMany('planet')
+    });
+
+    store = createStore({
+      models: {
+        planet: Planet,
+        moon: Moon,
+        star: Star
+      }
+    });
+
+    store.container.register("observer:planet", PlanetObserver);
+    planetObserver = store.container.lookup("observer:planet");
+  },
+
+  teardown: function() {
+    Orbit.Promise = null;
+    Planet = null;
+    Moon = null;
+    Star = null;
+    store = null;
+    planetObserver = null;
+  }
+});
+
+test("add record fires afterAddRecord hook", function(){
+  expect(1);
+  stop();
+
+  var jupiterDetails = {name: "Jupiter"};
+
+  store.add('planet', jupiterDetails).then(function(){
+    start();
+    var jupiter = store.all('planet').objectAt(0);
+
+    var callbackArgs = planetObserver.afterAddRecord.firstCall.args;
+    deepEqual(callbackArgs, [jupiter], 'afterAddRecord triggered with record');
+  });
+});
+
+test("remove record fires afterRemoveRecord hook", function(){
+  expect(1);
+  stop();
+
+  var jupiterDetails = {name: "Jupiter"};
+
+  store.add('planet', jupiterDetails)
+    .then(function(jupiter){
+      store.remove('planet', jupiter.get("id"))
+        .then(function(){
+          start();
+          var callbackArgs = planetObserver.afterRemoveRecord.firstCall.args;
+          deepEqual(callbackArgs, [jupiter], 'afterRemoveRecord triggered with record');
+        });
+    });
+});
+
+test("patch record fires afterPatchRecord hook", function(){
+  expect(1);
+  stop();
+
+  var jupiterDetails = {name: 'Jupiter'};
+
+  store.add('planet', jupiterDetails).then(function(jupiter){
+    store.patch('planet', jupiter.get('id'), 'name', 'Jupiter2').then(function(){
+      start();
+      var callbackArgs = planetObserver.afterPatchRecord.firstCall.args;
+      deepEqual(callbackArgs, [jupiter, 'name', 'Jupiter2'], 'afterPatchRecord triggered with record, field and value');
+    });
+  });
+});
+
+test("add link to hasMany fires afterAddLink hook", function(){
+  expect(1);
+  stop();
+
+  var jupiterDetails = {name: "Jupiter"};
+  var moonDetails = {name: "callisto"};
+
+  Ember.RSVP.all([
+    store.add('planet', jupiterDetails),
+    store.add('moon', moonDetails)
+
+  ]).then(spread(function(jupiter, callisto){
+    store.addLink('planet', jupiter.get('id'), 'moons', callisto.get('id')).then(function(){
+      start();
+      var callbackArgs = planetObserver.afterAddLink.firstCall.args;
+      deepEqual(callbackArgs, [jupiter, 'moons', callisto], 'afterAddLink triggered with record, link and value');
+    });
+
+  }));
+});
+
+test("remove link from hasMany fires afterRemoveLink hook", function(){
+  expect(1);
+  stop();
+
+  var jupiterDetails = {name: "Jupiter"};
+  var moonDetails = {name: "callisto"};
+
+  Ember.RSVP.all([
+    store.add('planet', jupiterDetails),
+    store.add('moon', moonDetails)
+
+  ]).then(spread(function(jupiter, callisto){
+    store.addLink('planet', jupiter.get('id'), 'moons', callisto.get('id')).then(function(){
+      return store.removeLink('planet', jupiter.get('id'), 'moons', callisto.get('id'));
+
+    }).then(function(){
+      start();
+      var callbackArgs = planetObserver.afterRemoveLink.firstCall.args;
+      deepEqual(callbackArgs, [jupiter, 'moons', callisto], 'afterRemoveLink triggered with record, link and value');
+    });
+
+  }));
+});
+
+test("add link to hasOne fires afterAddLink hook", function(){
+  expect(1);
+  stop();
+
+  var jupiterDetails = {name: "Jupiter"};
+  var starDetails = {name: "The Sun"};
+
+  Ember.RSVP.all([
+    store.add('planet', jupiterDetails),
+    store.add('star', starDetails)
+
+  ]).then(spread(function(jupiter, sun){
+    store.addLink('planet', jupiter.get('id'), 'sun', sun.get('id')).then(function(){
+      start();
+      var callbackArgs = planetObserver.afterAddLink.firstCall.args;
+      deepEqual(callbackArgs, [jupiter, 'sun', sun], 'afterAddLink triggered with record, link and value');
+    });
+
+  }));
+});
+
+test("remove link from hasOne fires afterRemoveLink hook", function(){
+  expect(1);
+  stop();
+
+  var jupiterDetails = {name: "Jupiter"};
+  var starDetails = {name: "The Sun"};
+
+  Ember.RSVP.all([
+    store.add('planet', jupiterDetails),
+    store.add('star', starDetails)
+
+  ]).then(spread(function(jupiter, sun){
+    store.addLink('planet', jupiter.get('id'), 'sun', sun.get('id')).then(function(){
+      return store.removeLink('planet', jupiter.get('id'), 'sun', sun.get('id'));
+
+    }).then(function(){
+      start();
+      var callbackArgs = planetObserver.afterRemoveLink.firstCall.args;
+      deepEqual(callbackArgs, [jupiter, 'sun', sun], 'afterRemoveLink triggered with record, link and value');
+    });
+
+  }));
+});

--- a/test/tests/unit/store-test.js
+++ b/test/tests/unit/store-test.js
@@ -211,6 +211,26 @@ test("#find will asynchronously return an array of records when called with a `t
   });
 });
 
+test("#find passes options through to find on the orbit source", function(){
+  expect(1);
+
+  var options = {include: 'moons'};
+  store.orbitSource.find = sinon.stub().returns(Ember.RSVP.resolve({}));
+
+  store.find('planet', 'planet1', options);
+  ok(store.orbitSource.find.calledWith('planet', 'planet1', options), "options were passed through");
+});
+
+test("#findLinked passes options through to findLinked on the orbit source", function(){
+  expect(1);
+
+  var options = {include: 'moons'};
+  store.orbitSource.findLinked = sinon.stub().returns(Ember.RSVP.resolve({}));
+
+  store.findLinked('planet', 'planet1', 'moons', options);
+  ok(store.orbitSource.findLinked.calledWith('planet', 'planet1', 'moons', options), "options were passed through");
+});
+
 test("#remove will asynchronously remove a record when called with a `type` and a single `id`", function() {
   expect(2);
 

--- a/test/tests/unit/store-test.js
+++ b/test/tests/unit/store-test.js
@@ -313,6 +313,17 @@ test("#retrieve can synchronously retrieve all records of a particular type", fu
   });
 });
 
+test("#retrieveLinks throws an error if the link hasn't been loaded yet", function(){
+  store.orbitSource.retrieve = sinon.stub().withArgs(['planet', 'planet1', '__rel', 'moons']).returns(undefined);
+
+  try {
+    store.retrieveLinks('planet', 'planet1', 'moons');
+  }
+  catch(error){
+    equal(error.message, "Link planet/planet1/moons is not loaded. Add it to your includes e.g. find('planet', 'planet1', {include: ['moons']})");
+  }
+});
+
 test("#all returns a live RecordArray that stays in sync with records of one type", function() {
   expect(4);
 


### PR DESCRIPTION
We're using this implementation of hooks for our internal beta (it supercedes https://github.com/orbitjs/ember-orbit/pull/61). 

We've introduced an observers directory with an observer for each type e.g.

    # ember-app/app/observers/task.js
    import Ember from 'ember';

    export default Ember.Object.extend(Ember.Evented, {
      name: "task-observer",
      activityStreamService: Ember.inject.service('activityStream'),

      logMovedTaskList: function(task, field, value){
        if(field === 'taskList'){
          var user = this.get('session.currentUser');
          this.get('activityStreamService').addMovedTaskList(task, user, value);
        }
      }.on("afterAddLink")
    });

To respond to a hook you add a method and tag the hook that you want it to respond to using ember's "on" (the observer is expected to implement Ember.Evented).

I tried to keep the hooks close to orbit's model so the available hooks are:  afterAddRecordListener, afterRemoveRecordListener, afterPatchRecordListener, afterAddLinkListener and afterRemoveLinkListener.

We haven't needed 'before' hooks yet so they're not included (but potentially could be added to this PR). 
