### PR TITLE
Correct travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "0.12"
+  - "4.0"
 
 sudo: false
 

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "ember-qunit": "0.4.9",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
-    "orbit.js": "~0.7.0-beta.2",
+    "orbit.js": "orbitjs/orbit.js#rethink",
     "jquery": "^1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1",
     "qunit": "~1.20.0",

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "ember": "^2.0.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.1.0",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
+    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.7",
     "ember-qunit": "0.4.9",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
     "ember-disable-prototype-extensions": "^1.0.0",
-    "ember-try": "0.0.6"
+    "ember-try": "0.0.8"
   },
   "keywords": [
     "ember-addon",

--- a/testem.json
+++ b/testem.json
@@ -1,16 +1,12 @@
 {
   "framework": "qunit",
-  "before_tests": "npm run build",
-  "src_files": [
-    "lib/**/*.js",
-    "test/**/*.js"
+  "test_page": "tests/index.html?hidepassed",
+  "disable_watching": true,
+  "launch_in_ci": [
+    "PhantomJS"
   ],
-  "serve_files": [
-    "test/ember-env.js",
-    "build/assets/loader.js",
-    "build/assets/vendor.js",
-    "build/assets/tests.amd.js",
-    "build/assets/test-support.js"
-  ],
-  "launch_in_ci": ["Firefox"]
+  "launch_in_dev": [
+    "PhantomJS",
+    "Chrome"
+  ]
 }


### PR DESCRIPTION
@dgeb I think the only thing left to get this green is a release of the current version of orbit.js#rethink. 

While things are moving quickly it would be nice if we had every push to orbit published so we could always refer to a specific version in ember-orbit. Ideally we'd have a tag for every commit, maybe we could keep them in a separate repo(to avoid polluting the tags in orbit-builds), something like orbit-dev-builds#commit-abc123 corresponding to orbitjs/orbit.js#abc123. Given time constraints though it may not be worth the effort at the moment...

