### PR TITLE
Require `schema` to be injected onto a Store.

### DIFF
--- a/addon/store.js
+++ b/addon/store.js
@@ -60,13 +60,7 @@ export default Ember.Object.extend({
   init() {
     this._super(...arguments);
 
-    if (!this.schema) {
-      const owner = getOwner(this);
-      this.schema = owner.lookup('schema:main');
-      if (!this.schema) {
-        this.schema = Schema.create(owner.ownerInjection());
-      }
-    }
+    assert("`schema` must be injected onto a Store", this.schema);
 
     if (!this.orbitStore) {
       this.orbitStore = new OrbitStore({ schema: this.schema.orbitSchema });
@@ -135,7 +129,7 @@ export default Ember.Object.extend({
   },
 
   _verifyType(type) {
-    Ember.assert("`type` must be registered as a model in the container", get(this, 'schema').modelFor(type));
+    assert("`type` must be registered as a model in the container", get(this, 'schema').modelFor(type));
   },
 
   _didPatch: function(operation) {

--- a/addon/transaction.js
+++ b/addon/transaction.js
@@ -22,7 +22,10 @@ Store.reopen({
   createTransaction(options = {}) {
     return Transaction.create(
       getOwner(this).ownerInjection(),
-      { orbitStore: this.get('orbitStore').createTransaction(options) }
+      {
+        orbitStore: this.orbitStore.createTransaction(options),
+        schema: this.schema
+      }
     );
   }
 });

--- a/tests/support/store.js
+++ b/tests/support/store.js
@@ -22,6 +22,7 @@ function createStore(options) {
 
   owner.register('schema:main', Schema);
   owner.register('store:main', Store);
+  owner.inject('store', 'schema', 'schema:main');
 
   const models = options.models;
   if (models) {


### PR DESCRIPTION
Stores should not create their own schemas. This was backwards.