### PR TITLE
Store refactor

### DIFF
--- a/addon/model.js
+++ b/addon/model.js
@@ -30,7 +30,7 @@ const Model = Ember.Object.extend(Ember.Evented, {
 
   replaceKey(field, value) {
     const store = get(this, '_storeOrError');
-    store.transform(t => t.replaceKey(this.getIdentifier(), field, value));
+    store.update(t => t.replaceKey(this.getIdentifier(), field, value));
   },
 
   getAttribute(field) {
@@ -46,7 +46,7 @@ const Model = Ember.Object.extend(Ember.Evented, {
   replaceHasOne(relationship, record) {
     const store = get(this, '_storeOrError');
     const recordIdentifier = record && record.getIdentifier();
-    store.transform(t => t.replaceHasOne(this.getIdentifier(), relationship, recordIdentifier));
+    store.update(t => t.replaceHasOne(this.getIdentifier(), relationship, recordIdentifier));
   },
 
   getHasMany(field) {
@@ -64,7 +64,7 @@ const Model = Ember.Object.extend(Ember.Evented, {
 
   replaceAttribute(attribute, value) {
     const store = get(this, '_storeOrError');
-    store.transform(t => t.replaceAttribute(this.getIdentifier(), attribute, value));
+    store.update(t => t.replaceAttribute(this.getIdentifier(), attribute, value));
   },
 
   remove() {

--- a/addon/relationships/has-many.js
+++ b/addon/relationships/has-many.js
@@ -9,7 +9,7 @@ export default ReadOnlyArrayProxy.extend({
     const model = this.get('_model');
     const relationship = this.get('_relationship');
 
-    store.transform(t => t.addToHasMany(model.getIdentifier(), relationship, record.getIdentifier()));
+    store.update(t => t.addToHasMany(model.getIdentifier(), relationship, record.getIdentifier()));
   },
 
   removeObject(record) {
@@ -17,6 +17,6 @@ export default ReadOnlyArrayProxy.extend({
     const model = this.get('_model');
     const relationship = this.get('_relationship');
 
-    store.transform(t => t.removeFromHasMany(model.getIdentifier(), relationship, record.getIdentifier()));
+    store.update(t => t.removeFromHasMany(model.getIdentifier(), relationship, record.getIdentifier()));
   }
 });

--- a/addon/store.js
+++ b/addon/store.js
@@ -36,11 +36,6 @@ export default Ember.Object.extend({
     orbitCache.patches.subscribe(operation => this._didPatch(operation));
   },
 
-  willDestroy: function() {
-    this.orbitStore.off('didTransform', this.didTransform, this);
-    this._super(...arguments);
-  },
-
   // query: function(type, query, options) {
   //   var _this = this;
   //   this._verifyType(type);

--- a/addon/store.js
+++ b/addon/store.js
@@ -48,10 +48,11 @@ export default Ember.Object.extend({
     this._verifyType(properties.type);
 
     const normalizedProperties = this.schema.normalize(properties);
-    return this.orbitStore.update(t => t.addRecord(normalizedProperties)).then(() => {
-      const { type, id } = normalizedProperties;
-      return this._identityMap.lookup({ type, id });
-    });
+    return this.update(t => t.addRecord(normalizedProperties))
+      .then(() => {
+        const { type, id } = normalizedProperties;
+        return this._identityMap.lookup({ type, id });
+      });
   },
 
   findRecord(type, id) {
@@ -60,7 +61,7 @@ export default Ember.Object.extend({
   },
 
   removeRecord(record) {
-    return this.orbitStore.transform(t => t.removeRecord(record.getIdentifier()));
+    return this.update(t => t.removeRecord(record.getIdentifier()));
   },
 
   _verifyType(type) {

--- a/addon/store.js
+++ b/addon/store.js
@@ -96,11 +96,11 @@ export default Ember.Object.extend({
   //   return this._request(promise);
   // },
 
-  transform(...args) {
+  update(...args) {
     const orbitStore = this.get('orbitStore');
     const transformTracker = this.get('_transformTracker');
 
-    const promisedTransform = orbitStore.transform(...args);
+    const promisedTransform = orbitStore.update(...args);
     transformTracker.track(promisedTransform);
 
     return promisedTransform;

--- a/addon/store.js
+++ b/addon/store.js
@@ -36,16 +36,9 @@ export default Ember.Object.extend({
     orbitCache.patches.subscribe(operation => this._didPatch(operation));
   },
 
-  // query: function(type, query, options) {
-  //   var _this = this;
-  //   this._verifyType(type);
-
-  //   var promise = this.orbitSource.query(type, query, options).then(function(data) {
-  //     return _this._lookupFromData(type, data);
-  //   });
-
-  //   return this._request(promise);
-  // },
+  query(...args) {
+    return this.orbitStore.query(...args);
+  },
 
   update(...args) {
     return this.orbitStore.update(...args);
@@ -62,8 +55,7 @@ export default Ember.Object.extend({
   },
 
   findRecord(type, id) {
-    return this.orbitStore
-      .query(q => q.record({type, id}))
+    return this.query(q => q.record({type, id}))
       .then(record => this._identityMap.lookup(record));
   },
 

--- a/tests/integration/cache-test.js
+++ b/tests/integration/cache-test.js
@@ -31,9 +31,10 @@ module('Integration - Cache', function(hooks) {
     const liveQuery = cache.liveQuery(q => q.recordsOfType('planet')
                                            .filterAttributes({ name: 'Jupiter' }));
 
-    store.transform(t => t.replaceAttribute({ type: 'planet', id: 'jupiter' }, 'name', 'Jupiter'));
-
-    assert.equal(liveQuery.get('length'), 1);
+    return store.update(t => t.replaceAttribute({ type: 'planet', id: 'jupiter' }, 'name', 'Jupiter'))
+      .then(() => {
+        assert.equal(liveQuery.get('length'), 1);
+      });
   });
 
   test('liveQuery - updates when matching record is added', function(assert) {
@@ -80,7 +81,7 @@ module('Integration - Cache', function(hooks) {
 
       store
         .addRecord({type: 'planet', name: 'Jupiter'})
-        .tap(jupiter => store.transform(t => t.replaceAttribute(jupiter.getIdentifier(), 'name', 'Jupiter2')))
+        .tap(jupiter => store.update(t => t.replaceAttribute(jupiter.getIdentifier(), 'name', 'Jupiter2')))
         .then(jupiter => assert.ok(!planets.contains(jupiter)))
         .then(() => done());
     });

--- a/tests/integration/model-test.js
+++ b/tests/integration/model-test.js
@@ -67,7 +67,7 @@ module('Integration - Model', function(hooks) {
       .tap(([jupiter, callisto]) => {
         jupiter.get('moons').pushObject(callisto);
         console.debug('pushed');
-        return store.then(() => console.debug('boo')).then(() => [jupiter, callisto]);
+        return [jupiter, callisto];
       })
       .then(([jupiter, callisto]) => {
         console.debug('asserting');


### PR DESCRIPTION
A number of minor refactors to the Store in the `rethink` branch:

* `transform` => `update` - since general updates should engage with the request flow
* remove half-baked transform tracking from Store
* initial implementation of `Store#query` that just proxies to the underlying `orbitStore.query`

Still working on the model-aware operators which will be coming soon.