### PR TITLE
Rethink queries

### DIFF
--- a/addon/cache.js
+++ b/addon/cache.js
@@ -15,47 +15,38 @@ export default Ember.Object.extend({
   },
 
   retrieve(path) {
-    return get(this, '_orbitCache').get(path);
+    return this._orbitCache.get(path);
   },
 
   retrieveRecord(type, id) {
-    return this.get('_identityMap').lookup({type, id});
+    return this._identityMap.lookup({type, id});
   },
 
   retrieveKey(record, key) {
-    const type = get(record.constructor, 'typeKey');
-    const id = get(record, 'id');
-
-    return this.retrieve([type, id, 'keys', key]);
+    return this.retrieve([record.type, record.id, 'keys', key]);
   },
 
   retrieveAttribute(record, attribute) {
-    const type = get(record.constructor, 'typeKey');
-    const id = get(record, 'id');
-
-    return this.retrieve([type, id, 'attributes', attribute]);
+    return this.retrieve([record.type, record.id, 'attributes', attribute]);
   },
 
   retrieveHasOne(record, relationship) {
-    const type = get(record.constructor, 'typeKey');
-    const id = get(record, 'id');
-
-    const value = this.retrieve([type, id, 'relationships', relationship, 'data']);
+    const value = this.retrieve([record.type, record.id, 'relationships', relationship, 'data']);
     if (!value) return null;
 
-    return this.get('_identityMap').lookup(parseIdentifier(value));
+    return this._identityMap.lookup(parseIdentifier(value));
   },
 
   unload(record) {
     console.debug('unload', record);
-    this.get('_identityMap').evict(record);
+    this._identityMap.evict(record);
   },
 
   liveQuery(query) {
     return LiveQuery.create({
       _query: query,
-      _orbitCache: this.get('_orbitCache'),
-      _identityMap: this.get('_identityMap')
+      _orbitCache: this._orbitCache,
+      _identityMap: this._identityMap
     });
   },
 });

--- a/addon/cache.js
+++ b/addon/cache.js
@@ -2,6 +2,7 @@ const get = Ember.get;
 
 import LiveQuery from 'ember-orbit/live-query';
 import { parseIdentifier } from 'orbit-common/lib/identifiers';
+import Query from 'orbit/query';
 
 export default Ember.Object.extend({
   _orbitCache: null,
@@ -40,6 +41,18 @@ export default Ember.Object.extend({
   unload(record) {
     console.debug('unload', record);
     this._identityMap.evict(record);
+  },
+
+  query(queryOrExpression) {
+    const query = Query.from(queryOrExpression, this._orbitCache.queryBuilder);
+    const result = this._orbitCache.query(query);
+
+    switch(query.expression.op) {
+      case 'record':        return this._identityMap.lookup(result);
+      case 'recordsOfType': return this._identityMap.lookupMany(Object.values(result));
+      case 'filter':        return this._identityMap.lookupMany(Object.values(result));
+      default:              return result;
+    }
   },
 
   liveQuery(query) {

--- a/addon/identity-map.js
+++ b/addon/identity-map.js
@@ -16,7 +16,7 @@ export default Ember.Object.extend({
   },
 
   lookup(identifier) {
-    if(!identifier) return;
+    if (!identifier) return;
 
     const { type, id } = identifier;
 
@@ -26,8 +26,12 @@ export default Ember.Object.extend({
     return materialized[identifierKey] || this._materialize(type, id);
   },
 
+  lookupMany(identifiers) {
+    return identifiers.map(identifier => this.lookup(identifier));
+  },
+
   contains(identifier) {
-    if(!identifier) return;
+    if (!identifier) return;
 
     const { type, id } = identifier;
 

--- a/addon/identity-map.js
+++ b/addon/identity-map.js
@@ -7,23 +7,21 @@ export default Ember.Object.extend({
   _store: null,
 
   init(...args) {
-    this._super.apply(this, ...args);
+    this._super(...args);
 
-    Ember.assert(this.get('_schema'), '_schema is required');
-    Ember.assert(this.get('_orbitCache'), '_orbitCache is required');
+    Ember.assert(this._schema, '_schema is required');
+    Ember.assert(this._orbitCache, '_orbitCache is required');
 
-    this.set('_materialized', {});
+    this._materialized = {};
   },
 
   lookup(identifier) {
     if (!identifier) return;
 
     const { type, id } = identifier;
-
-    const materialized = this.get('_materialized');
     const identifierKey = this._identifierKey(type, id);
 
-    return materialized[identifierKey] || this._materialize(type, id);
+    return this._materialized[identifierKey] || this._materialize(type, id);
   },
 
   lookupMany(identifiers) {
@@ -34,39 +32,26 @@ export default Ember.Object.extend({
     if (!identifier) return;
 
     const { type, id } = identifier;
-
-    const materialized = this.get('_materialized');
     const identifierKey = this._identifierKey(type, id);
 
-    return !!materialized[identifierKey];
-  },
-
-  identifier(record) {
-    return {
-      type: get(record.constructor, 'typeKey'),
-      id: record.get('id')
-    };
+    return !!this._materialized[identifierKey];
   },
 
   evict(record) {
-    console.debug('evicting', record);
-    const materialized = this.get('_materialized');
+    // console.debug('evicting', record);
     const identifierKey = this._identifierKey(record.type, record.id);
-    delete materialized[identifierKey];
-    console.debug('materialized after evict', identifierKey, materialized);
+    delete this._materialized[identifierKey];
+    // console.debug('materialized after evict', identifierKey, this._materialized);
     record.disconnect();
   },
 
   _materialize(type, id) {
-    console.debug('materializing', type, id);
-    const schema = this.get('_schema');
-    const store = this.get('_store');
-    const materialized = this.get('_materialized');
-    const model = schema.modelFor(type);
-    const record = model._create(id, store);
+    // console.debug('materializing', type, id);
+    const model = this._schema.modelFor(type);
+    const record = model._create(id, this._store);
     const identifier = this._identifierKey(type, id);
 
-    materialized[identifier] = record;
+    this._materialized[identifier] = record;
 
     return record;
   },

--- a/addon/identity-map.js
+++ b/addon/identity-map.js
@@ -18,7 +18,7 @@ export default Ember.Object.extend({
   lookup(identifier) {
     if(!identifier) return;
 
-    const {type, id} = identifier;
+    const { type, id } = identifier;
 
     const materialized = this.get('_materialized');
     const identifierKey = this._identifierKey(type, id);
@@ -29,7 +29,7 @@ export default Ember.Object.extend({
   contains(identifier) {
     if(!identifier) return;
 
-    const {type, id} = identifier;
+    const { type, id } = identifier;
 
     const materialized = this.get('_materialized');
     const identifierKey = this._identifierKey(type, id);
@@ -47,8 +47,7 @@ export default Ember.Object.extend({
   evict(record) {
     console.debug('evicting', record);
     const materialized = this.get('_materialized');
-    const identifier = record.getIdentifier();
-    const identifierKey = this._identifierKey(identifier.type, identifier.id);
+    const identifierKey = this._identifierKey(record.type, record.id);
     delete materialized[identifierKey];
     console.debug('materialized after evict', identifierKey, materialized);
     record.disconnect();
@@ -59,8 +58,6 @@ export default Ember.Object.extend({
     const schema = this.get('_schema');
     const store = this.get('_store');
     const materialized = this.get('_materialized');
-
-
     const model = schema.modelFor(type);
     const record = model._create(id, store);
     const identifier = this._identifierKey(type, id);

--- a/addon/live-query.js
+++ b/addon/live-query.js
@@ -1,4 +1,7 @@
 import ReadOnlyArrayProxy from 'ember-orbit/system/read-only-array-proxy';
+import Ember from 'ember';
+
+const { get, set } = Ember;
 
 export default ReadOnlyArrayProxy.extend({
   _orbitCache: null,
@@ -6,17 +9,15 @@ export default ReadOnlyArrayProxy.extend({
   _identityMap: null,
 
   init(...args) {
-    console.debug('creating liveQuery', this);
-    this.set('content', Ember.A());
-
+    // console.debug('creating liveQuery', this);
     this._super(...args);
 
-    const orbitCache = this.get('_orbitCache');
-    const query = this.get('_query');
-    const orbitLiveQuery = orbitCache.liveQuery(query);
+    set(this, 'content', Ember.A());
+
+    const orbitLiveQuery = this._orbitCache.liveQuery(this._query);
 
     orbitLiveQuery.subscribe((operation) => {
-      console.debug('liveQuery', operation);
+      // console.debug('liveQuery', operation);
 
       const handler = `_${operation.op}`;
 
@@ -30,17 +31,15 @@ export default ReadOnlyArrayProxy.extend({
 
   _addRecord(operation) {
     const record = this._recordFor(operation);
-    this.get('content').pushObject(record);
+    get(this, 'content').pushObject(record);
   },
 
   _removeRecord(operation) {
     const record = this._recordFor(operation);
-    this.get('content').removeObject(record);
+    get(this, 'content').removeObject(record);
   },
 
   _recordFor(operation) {
-    const identityMap = this.get('_identityMap');
-    const { type, id } = operation.record;
-    return identityMap.lookup({id, type});
+    return this._identityMap.lookup(operation.record);
   }
 });

--- a/addon/model.js
+++ b/addon/model.js
@@ -30,7 +30,7 @@ const Model = Ember.Object.extend(Ember.Evented, {
 
   replaceKey(field, value) {
     const store = get(this, '_storeOrError');
-    store.transform(t => t.replaceKey(this.getIdentifier(), field, value));
+    store.update(t => t.replaceKey(this.getIdentifier(), field, value));
   },
 
   getAttribute(field) {
@@ -46,7 +46,7 @@ const Model = Ember.Object.extend(Ember.Evented, {
   replaceHasOne(relationship, record) {
     const store = get(this, '_storeOrError');
     const recordIdentifier = record && record.getIdentifier();
-    store.transform(t => t.replaceHasOne(this.getIdentifier(), relationship, recordIdentifier));
+    store.update(t => t.replaceHasOne(this.getIdentifier(), relationship, recordIdentifier));
   },
 
   getHasMany(field) {
@@ -64,7 +64,7 @@ const Model = Ember.Object.extend(Ember.Evented, {
 
   replaceAttribute(attribute, value) {
     const store = get(this, '_storeOrError');
-    store.transform(t => t.replaceAttribute(this.getIdentifier(), attribute, value));
+    store.update(t => t.replaceAttribute(this.getIdentifier(), attribute, value));
   },
 
   remove() {

--- a/addon/model.js
+++ b/addon/model.js
@@ -7,7 +7,7 @@ import { queryExpression as oqe } from 'orbit/query/expression';
  @module ember-orbit
  */
 
-const get = Ember.get;
+const { get, set } = Ember;
 
 /**
  @class Model
@@ -34,6 +34,11 @@ const Model = Ember.Object.extend(Ember.Evented, {
     return cache.retrieveAttribute(this, field);
   },
 
+  replaceAttribute(attribute, value) {
+    const store = get(this, '_storeOrError');
+    store.update(t => t.replaceAttribute(this, attribute, value));
+  },
+
   getHasOne(relationship) {
     const cache = get(this, '_storeOrError.cache');
     return cache.retrieveHasOne(this, relationship);
@@ -56,18 +61,13 @@ const Model = Ember.Object.extend(Ember.Evented, {
     });
   },
 
-  replaceAttribute(attribute, value) {
-    const store = get(this, '_storeOrError');
-    store.update(t => t.replaceAttribute(this, attribute, value));
-  },
-
   remove() {
     const store = get(this, '_storeOrError');
     return store.removeRecord(this);
   },
 
   disconnect() {
-    this.set('_store', null);
+    set(this, '_store', null);
   },
 
   willDestroy() {

--- a/addon/relationships/has-many.js
+++ b/addon/relationships/has-many.js
@@ -9,7 +9,7 @@ export default ReadOnlyArrayProxy.extend({
     const model = this.get('_model');
     const relationship = this.get('_relationship');
 
-    store.update(t => t.addToHasMany(model.getIdentifier(), relationship, record.getIdentifier()));
+    store.update(t => t.addToHasMany(model, relationship, record));
   },
 
   removeObject(record) {
@@ -17,6 +17,6 @@ export default ReadOnlyArrayProxy.extend({
     const model = this.get('_model');
     const relationship = this.get('_relationship');
 
-    store.update(t => t.removeFromHasMany(model.getIdentifier(), relationship, record.getIdentifier()));
+    store.update(t => t.removeFromHasMany(model, relationship, record));
   }
 });

--- a/addon/relationships/has-many.js
+++ b/addon/relationships/has-many.js
@@ -9,7 +9,7 @@ export default ReadOnlyArrayProxy.extend({
     const model = this.get('_model');
     const relationship = this.get('_relationship');
 
-    store.transform(t => t.addToHasMany(model.getIdentifier(), relationship, record.getIdentifier()));
+    store.update(t => t.addToHasMany(model.getIdentifier(), relationship, record.getIdentifier()));
   },
 
   removeObject(record) {
@@ -17,6 +17,6 @@ export default ReadOnlyArrayProxy.extend({
     const model = this.get('_model');
     const relationship = this.get('_relationship');
 
-    store.transform(t => t.removeFromHasMany(model.getIdentifier(), relationship, record.getIdentifier()));
+    store.update(t => t.removeFromHasMany(model.getIdentifier(), relationship, record.getIdentifier()));
   }
 });

--- a/addon/store.js
+++ b/addon/store.js
@@ -36,11 +36,6 @@ export default Ember.Object.extend({
     orbitCache.patches.subscribe(operation => this._didPatch(operation));
   },
 
-  willDestroy: function() {
-    this.orbitStore.off('didTransform', this.didTransform, this);
-    this._super(...arguments);
-  },
-
   // query: function(type, query, options) {
   //   var _this = this;
   //   this._verifyType(type);

--- a/addon/store.js
+++ b/addon/store.js
@@ -48,10 +48,11 @@ export default Ember.Object.extend({
     this._verifyType(properties.type);
 
     const normalizedProperties = this.schema.normalize(properties);
-    return this.orbitStore.update(t => t.addRecord(normalizedProperties)).then(() => {
-      const { type, id } = normalizedProperties;
-      return this._identityMap.lookup({ type, id });
-    });
+    return this.update(t => t.addRecord(normalizedProperties))
+      .then(() => {
+        const { type, id } = normalizedProperties;
+        return this._identityMap.lookup({ type, id });
+      });
   },
 
   findRecord(type, id) {
@@ -60,7 +61,7 @@ export default Ember.Object.extend({
   },
 
   removeRecord(record) {
-    return this.orbitStore.transform(t => t.removeRecord(record.getIdentifier()));
+    return this.update(t => t.removeRecord(record.getIdentifier()));
   },
 
   _verifyType(type) {

--- a/addon/store.js
+++ b/addon/store.js
@@ -61,7 +61,7 @@ export default Ember.Object.extend({
   },
 
   removeRecord(record) {
-    return this.update(t => t.removeRecord(record.getIdentifier()));
+    return this.update(t => t.removeRecord(record));
   },
 
   _verifyType(type) {

--- a/addon/store.js
+++ b/addon/store.js
@@ -96,11 +96,11 @@ export default Ember.Object.extend({
   //   return this._request(promise);
   // },
 
-  transform(...args) {
+  update(...args) {
     const orbitStore = this.get('orbitStore');
     const transformTracker = this.get('_transformTracker');
 
-    const promisedTransform = orbitStore.transform(...args);
+    const promisedTransform = orbitStore.update(...args);
     transformTracker.track(promisedTransform);
 
     return promisedTransform;

--- a/addon/store.js
+++ b/addon/store.js
@@ -36,16 +36,9 @@ export default Ember.Object.extend({
     orbitCache.patches.subscribe(operation => this._didPatch(operation));
   },
 
-  // query: function(type, query, options) {
-  //   var _this = this;
-  //   this._verifyType(type);
-
-  //   var promise = this.orbitSource.query(type, query, options).then(function(data) {
-  //     return _this._lookupFromData(type, data);
-  //   });
-
-  //   return this._request(promise);
-  // },
+  query(...args) {
+    return this.orbitStore.query(...args);
+  },
 
   update(...args) {
     return this.orbitStore.update(...args);
@@ -62,8 +55,7 @@ export default Ember.Object.extend({
   },
 
   findRecord(type, id) {
-    return this.orbitStore
-      .query(q => q.record({type, id}))
+    return this.query(q => q.record({type, id}))
       .then(record => this._identityMap.lookup(record));
   },
 

--- a/addon/system/read-only-array-proxy.js
+++ b/addon/system/read-only-array-proxy.js
@@ -1,59 +1,22 @@
 const { ArrayProxy } = Ember;
 
+function notSupported() {
+  throw new Error('Method not supported on read-only ArrayProxy.');
+}
+
 export default ArrayProxy.extend({
-  addObject() {
-    throw new Error('not supported');
-  },
-
-  clear() {
-    throw new Error('not supported');
-  },
-
-  insertAt() {
-    throw new Error('not supported');
-  },
-
-  popObject() {
-    throw new Error('not supported');
-  },
-
-  pushObject() {
-    throw new Error('not supported');
-  },
-
-  pushObjects() {
-    throw new Error('not supported');
-  },
-
-  removeAt() {
-    throw new Error('not supported');
-  },
-
-  removeObject() {
-    throw new Error('not supported');
-  },
-
-  replace() {
-    throw new Error('not supported');
-  },
-
-  reverseObjects() {
-    throw new Error('not supported');
-  },
-
-  setObjects() {
-    throw new Error('not supported');
-  },
-
-  shiftObject() {
-    throw new Error('not supported');
-  },
-
-  unshiftObject() {
-    throw new Error('not supported');
-  },
-
-  unshiftObjects() {
-    throw new Error('not supported');
-  }
+  addObject: notSupported,
+  clear: notSupported,
+  insertAt: notSupported,
+  popObject: notSupported,
+  pushObject: notSupported,
+  pushObjects: notSupported,
+  removeAt: notSupported,
+  removeObject: notSupported,
+  replace: notSupported,
+  reverseObjects: notSupported,
+  setObjects: notSupported,
+  shiftObject: notSupported,
+  unshiftObject: notSupported,
+  unshiftObjects: notSupported
 });

--- a/tests/index.html
+++ b/tests/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Dummy Tests</title>
+    <title>Ember-Orbit Tests</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/tests/integration/cache-test.js
+++ b/tests/integration/cache-test.js
@@ -31,9 +31,10 @@ module('Integration - Cache', function(hooks) {
     const liveQuery = cache.liveQuery(q => q.recordsOfType('planet')
                                            .filterAttributes({ name: 'Jupiter' }));
 
-    store.transform(t => t.replaceAttribute({ type: 'planet', id: 'jupiter' }, 'name', 'Jupiter'));
-
-    assert.equal(liveQuery.get('length'), 1);
+    return store.update(t => t.replaceAttribute({ type: 'planet', id: 'jupiter' }, 'name', 'Jupiter'))
+      .then(() => {
+        assert.equal(liveQuery.get('length'), 1);
+      });
   });
 
   test('liveQuery - updates when matching record is added', function(assert) {
@@ -80,7 +81,7 @@ module('Integration - Cache', function(hooks) {
 
       store
         .addRecord({type: 'planet', name: 'Jupiter'})
-        .tap(jupiter => store.transform(t => t.replaceAttribute(jupiter.getIdentifier(), 'name', 'Jupiter2')))
+        .tap(jupiter => store.update(t => t.replaceAttribute(jupiter.getIdentifier(), 'name', 'Jupiter2')))
         .then(jupiter => assert.ok(!planets.contains(jupiter)))
         .then(() => done());
     });

--- a/tests/integration/cache-test.js
+++ b/tests/integration/cache-test.js
@@ -81,7 +81,7 @@ module('Integration - Cache', function(hooks) {
 
       store
         .addRecord({type: 'planet', name: 'Jupiter'})
-        .tap(jupiter => store.update(t => t.replaceAttribute(jupiter.getIdentifier(), 'name', 'Jupiter2')))
+        .tap(jupiter => store.update(t => t.replaceAttribute(jupiter, 'name', 'Jupiter2')))
         .then(jupiter => assert.ok(!planets.contains(jupiter)))
         .then(() => done());
     });

--- a/tests/integration/cache-test.js
+++ b/tests/integration/cache-test.js
@@ -87,7 +87,6 @@ module('Integration - Cache', function(hooks) {
     });
   });
 
-
   test('#retrieveAttribute', function(assert) {
     const done = assert.async();
 
@@ -139,5 +138,56 @@ module('Integration - Cache', function(hooks) {
         .then((record) => cache.retrieveRecord('planet', record.get('id')))
         .then((retrievedRecord) => assert.ok(retrievedRecord, 'retrieved record'));
     });
+  });
+
+  test('#query - record', function(assert) {
+    let earth, jupiter;
+
+    return store.addRecord({ type: 'planet', name: 'Earth' })
+      .then(record => {
+        earth = record;
+        return store.addRecord({ type: 'planet', name: 'Jupiter' });
+      })
+      .then(record => {
+        jupiter = record;
+
+        const foundRecord = cache.query(q => q.record(earth));
+        assert.strictEqual(foundRecord, earth);
+      });
+  });
+
+  test('#query - recordsOfType', function(assert) {
+    let earth, jupiter;
+
+    return store.addRecord({ type: 'planet', name: 'Earth' })
+      .then(record => {
+        earth = record;
+        return store.addRecord({ type: 'planet', name: 'Jupiter' });
+      })
+      .then(record => {
+        jupiter = record;
+
+        const foundRecords = cache.query(q => q.recordsOfType('planet'));
+        assert.deepEqual(foundRecords, [earth, jupiter]);
+        assert.strictEqual(foundRecords[0], earth);
+        assert.strictEqual(foundRecords[1], jupiter);
+      });
+  });
+
+  test('#query - filter', function(assert) {
+    let earth, jupiter;
+
+    return store.addRecord({ type: 'planet', name: 'Earth' })
+      .then(record => {
+        earth = record;
+        return store.addRecord({ type: 'planet', name: 'Jupiter' });
+      })
+      .then(record => {
+        jupiter = record;
+
+        const foundRecords = cache.query(q => q.recordsOfType('planet').filterAttributes({ name: 'Earth' }));
+        assert.deepEqual(foundRecords, [earth]);
+        assert.strictEqual(foundRecords[0], earth);
+      });
   });
 });

--- a/tests/integration/model-test.js
+++ b/tests/integration/model-test.js
@@ -67,7 +67,7 @@ module('Integration - Model', function(hooks) {
       .tap(([jupiter, callisto]) => {
         jupiter.get('moons').pushObject(callisto);
         console.debug('pushed');
-        return store.then(() => console.debug('boo')).then(() => [jupiter, callisto]);
+        return [jupiter, callisto];
       })
       .then(([jupiter, callisto]) => {
         console.debug('asserting');

--- a/tests/integration/store-test.js
+++ b/tests/integration/store-test.js
@@ -17,39 +17,84 @@ module('Integration - Store', function(hooks) {
   });
 
   test('#addRecord', function(assert) {
-    Ember.run(() => {
-      store
-        .addRecord({ type: 'planet', name: 'Earth' })
-        .then(function(planet) {
-           assert.ok(planet instanceof Planet);
-           assert.ok(get(planet, 'id'), 'assigned id');
-           assert.equal(get(planet, 'name'), 'Earth');
-        });
-    });
+    return store.addRecord({ type: 'planet', name: 'Earth' })
+      .then(function(planet) {
+         assert.ok(planet instanceof Planet);
+         assert.ok(get(planet, 'id'), 'assigned id');
+         assert.equal(get(planet, 'name'), 'Earth');
+      });
   });
 
   test('#findRecord', function(assert) {
-    Ember.run(() => {
-      store
-        .addRecord({ type: 'planet', name: 'Earth' })
-        .then( record => store.findRecord('planet', record.get('id')))
-        .then( planet => {
-          assert.ok(planet instanceof Planet);
-          assert.ok(get(planet, 'id'), 'assigned id');
-          assert.equal(get(planet, 'name'), 'Earth');
-        });
-    });
+    return store.addRecord({ type: 'planet', name: 'Earth' })
+      .then( record => store.findRecord('planet', record.get('id')))
+      .then( planet => {
+        assert.ok(planet instanceof Planet);
+        assert.ok(get(planet, 'id'), 'assigned id');
+        assert.equal(get(planet, 'name'), 'Earth');
+      });
   });
 
   test('#removeRecord', function(assert) {
-    Ember.run(() => {
-      store
-        .addRecord({ type: 'planet', name: 'Earth' })
-        .tap(record => store.removeRecord(record))
-        .then(record => store.findRecord('planet', record.get('id')))
-        .catch(error => {
-          assert.ok(error.message.match(/Record not found/));
-        });
-    });
+    return store.addRecord({ type: 'planet', name: 'Earth' })
+      .tap(record => store.removeRecord(record))
+      .then(record => store.findRecord('planet', record.get('id')))
+      .catch(error => {
+        assert.ok(error.message.match(/Record not found/));
+      });
+  });
+
+  test('#query - record', function(assert) {
+    let earth, jupiter;
+
+    return store.addRecord({ type: 'planet', name: 'Earth' })
+      .then(record => {
+        earth = record;
+        return store.addRecord({ type: 'planet', name: 'Jupiter' });
+      })
+      .then(record => {
+        jupiter = record;
+        return store.query(q => q.record(earth));
+      })
+      .then(record => {
+        assert.strictEqual(record, earth);
+      });
+  });
+
+  test('#query - recordsOfType', function(assert) {
+    let earth, jupiter;
+
+    return store.addRecord({ type: 'planet', name: 'Earth' })
+      .then(record => {
+        earth = record;
+        return store.addRecord({ type: 'planet', name: 'Jupiter' });
+      })
+      .then(record => {
+        jupiter = record;
+        return store.query(q => q.recordsOfType('planet'));
+      })
+      .then(records => {
+        assert.deepEqual(records, [earth, jupiter]);
+        assert.strictEqual(records[0], earth);
+        assert.strictEqual(records[1], jupiter);
+      });
+  });
+
+  test('#query - filter', function(assert) {
+    let earth, jupiter;
+
+    return store.addRecord({ type: 'planet', name: 'Earth' })
+      .then(record => {
+        earth = record;
+        return store.addRecord({ type: 'planet', name: 'Jupiter' });
+      })
+      .then(record => {
+        jupiter = record;
+        return store.query(q => q.recordsOfType('planet').filterAttributes({ name: 'Earth' }));
+      })
+      .then(records => {
+        assert.deepEqual(records, [earth]);
+        assert.strictEqual(records[0], earth);
+      });
   });
 });

--- a/tests/integration/store-test.js
+++ b/tests/integration/store-test.js
@@ -46,7 +46,7 @@ module('Integration - Store', function(hooks) {
       store
         .addRecord({ type: 'planet', name: 'Earth' })
         .tap(record => store.removeRecord(record))
-        .then(record => store.findRecord(record.getIdentifier()))
+        .then(record => store.findRecord('planet', record.get('id')))
         .catch(error => {
           assert.ok(error.message.match(/Record not found/));
         });


### PR DESCRIPTION
Builds off #96.

Introduces Model-aware `query` methods to both the Cache and Store.

Eliminates the need for the `Model#getIdentifier` method by adding a `type` property to model instances.