### PR TITLE
Introduce Store#find.

### DIFF
--- a/addon/store.js
+++ b/addon/store.js
@@ -37,6 +37,14 @@ export default Ember.Object.extend({
     orbitCache.patches.subscribe(operation => this._didPatch(operation));
   },
 
+  find(type, id) {
+    if (id === undefined) {
+      return this.query(q => q.recordsOfType(type));
+    } else {
+      return this.query(q => q.record({type, id}));
+    }
+  },
+
   query(queryOrExpression) {
     const query = Query.from(queryOrExpression, this.orbitStore.queryBuilder);
     return this.orbitStore.query(query)

--- a/tests/integration/store-test.js
+++ b/tests/integration/store-test.js
@@ -97,4 +97,40 @@ module('Integration - Store', function(hooks) {
         assert.strictEqual(records[0], earth);
       });
   });
+
+  test('#find - by type and id', function(assert) {
+    let earth, jupiter;
+
+    return store.addRecord({ type: 'planet', name: 'Earth' })
+      .then(record => {
+        earth = record;
+        return store.addRecord({ type: 'planet', name: 'Jupiter' });
+      })
+      .then(record => {
+        jupiter = record;
+        return store.find('planet', earth.id);
+      })
+      .then(record => {
+        assert.strictEqual(record, earth);
+      });
+  });
+
+  test('#find - by type', function(assert) {
+    let earth, jupiter;
+
+    return store.addRecord({ type: 'planet', name: 'Earth' })
+      .then(record => {
+        earth = record;
+        return store.addRecord({ type: 'planet', name: 'Jupiter' });
+      })
+      .then(record => {
+        jupiter = record;
+        return store.find('planet');
+      })
+      .then(records => {
+        assert.deepEqual(records, [earth, jupiter]);
+        assert.strictEqual(records[0], earth);
+        assert.strictEqual(records[1], jupiter);
+      });
+  });
 });


### PR DESCRIPTION
Satisfies the expectations of an Ember store to support finding records
by type, or by type + id.