### PR TITLE
Fix ReadOnlyArrayProxy implementation

### DIFF
--- a/addon/model.js
+++ b/addon/model.js
@@ -83,7 +83,7 @@ const Model = Ember.Object.extend(Ember.Evented, {
   },
 
   _storeOrError: Ember.computed('_store', function() {
-    const store = this.get('_store');
+    const store = get(this, '_store');
 
     if (!store) throw new Ember.Error('record has been removed from Store');
 

--- a/addon/relationships/has-many.js
+++ b/addon/relationships/has-many.js
@@ -9,7 +9,7 @@ export default ReadOnlyArrayProxy.extend({
     const model = this.get('_model');
     const relationship = this.get('_relationship');
 
-    store.update(t => t.addToHasMany(model, relationship, record));
+    return store.update(t => t.addToHasMany(model, relationship, record));
   },
 
   removeObject(record) {
@@ -17,6 +17,6 @@ export default ReadOnlyArrayProxy.extend({
     const model = this.get('_model');
     const relationship = this.get('_relationship');
 
-    store.update(t => t.removeFromHasMany(model, relationship, record));
+    return store.update(t => t.removeFromHasMany(model, relationship, record));
   }
 });

--- a/addon/system/read-only-array-proxy.js
+++ b/addon/system/read-only-array-proxy.js
@@ -1,4 +1,10 @@
-const { ArrayProxy } = Ember;
+import Ember from 'ember';
+
+const {
+  get,
+  set,
+  ArrayProxy
+} = Ember;
 
 function notSupported() {
   throw new Error('Method not supported on read-only ArrayProxy.');
@@ -18,5 +24,18 @@ export default ArrayProxy.extend({
   setObjects: notSupported,
   shiftObject: notSupported,
   unshiftObject: notSupported,
-  unshiftObjects: notSupported
+  unshiftObjects: notSupported,
+
+  length: Ember.computed.alias('content.length'),
+
+  init(...args) {
+    let content = get(this, 'content');
+
+    if (!content) {
+      content = Ember.A();
+      set(this, 'content', content);
+    }
+
+    this._super(...args);
+  }
 });

--- a/tests/integration/model-test.js
+++ b/tests/integration/model-test.js
@@ -65,9 +65,9 @@ module('Integration - Model', function(hooks) {
         store.addRecord({type: 'moon', name: 'Callisto'})
       ])
       .tap(([jupiter, callisto]) => {
-        jupiter.get('moons').pushObject(callisto);
-        console.debug('pushed');
-        return [jupiter, callisto];
+        return jupiter.get('moons').pushObject(callisto);
+        // console.debug('pushed');
+        // return [jupiter, callisto];
       })
       .then(([jupiter, callisto]) => {
         console.debug('asserting');


### PR DESCRIPTION
Content is now set before array observers are configured in ReadOnlyArrayProxy. 

This fixes array content observation for LiveQuery.
