### PR TITLE
HasMany array proxy now extends LiveQuery.

### DIFF
--- a/addon/model.js
+++ b/addon/model.js
@@ -51,10 +51,7 @@ const Model = Ember.Object.extend(Ember.Evented, {
 
   getHasMany(field) {
     const store = get(this, '_storeOrError');
-    const cache = get(store, 'cache');
-
     return HasMany.create({
-      content: cache.liveQuery(q => q.relatedRecords(this, field)),
       _store: store,
       _model: this,
       _relationship: field

--- a/addon/relationships/has-many.js
+++ b/addon/relationships/has-many.js
@@ -1,13 +1,31 @@
-import ReadOnlyArrayProxy from 'ember-orbit/system/read-only-array-proxy';
+import Ember from 'ember';
+import LiveQuery from '../live-query';
 
-export default ReadOnlyArrayProxy.extend({
+const { get } = Ember;
+
+export default LiveQuery.extend({
   _store: null,
   _model: null,
+  _relationship: null,
+
+  init(...args) {
+    const store = get(this, '_store');
+    const model = get(this, '_model');
+    const relationship = get(this, '_relationship');
+
+    this._orbitCache = store.cache._orbitCache;
+    this._identityMap = store.cache._identityMap;
+    this._query = (q) => q.relatedRecords(model, relationship);
+
+    this._super(...args);
+  },
 
   pushObject(record) {
-    const store = this.get('_store');
-    const model = this.get('_model');
-    const relationship = this.get('_relationship');
+    const store = get(this, '_store');
+    const model = get(this, '_model');
+    const relationship = get(this, '_relationship');
+
+    // console.log('pushObject', model.type, model.id, relationship, record.type, record.id);
 
     return store.update(t => t.addToHasMany(model, relationship, record));
   },


### PR DESCRIPTION
The HasMany array proxy now sets its query internally instead of 
requiring it to be passed in as `content`.