### PR TITLE
Ensure that babel polyfills are included in the target app.

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,8 +35,12 @@ module.exports = {
   },
 
   included: function(app) {
-    this._super.included(app);
-
     app.import('vendor/immutable/dist/immutable.min.js');
+
+    app.options = app.options || {};
+    app.options.babel = app.options.babel || {};
+    app.options.babel.includePolyfill = true;
+
+    return this._super.included(app);
   }
 };

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "broccoli-merge-trees": "^1.1.1",
     "ember-cli": "2.4.2",
     "ember-cli-app-version": "0.5.0",
-    "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.1",
     "ember-cli-htmlbars": "0.7.9",
     "ember-cli-htmlbars-inline-precompile": "^0.2.0",


### PR DESCRIPTION
Also, remove CSP as a dev dependency.