### PR TITLE
Remove babel polyfill

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@ bower_components/*
 dist/*
 tmp/*
 build-support/*
+travis_phantomjs/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ sudo: false
 cache:
   directories:
     - node_modules
+    - travis_phantomjs
 
 env:
   - EMBER_TRY_SCENARIO=default
@@ -21,7 +22,11 @@ matrix:
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
-  - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
+  - "export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then wget https://assets.membergetmember.co/software/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2; fi"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then tar -xvf $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis_phantomjs; fi"
+  - "phantomjs --version"
   - "npm config set spin false"
   - "npm install -g npm@^2"
 

--- a/addon/cache.js
+++ b/addon/cache.js
@@ -3,6 +3,7 @@ const get = Ember.get;
 import LiveQuery from 'ember-orbit/live-query';
 import { parseIdentifier } from 'orbit-common/lib/identifiers';
 import Query from 'orbit/query';
+import objectValues from 'ember-orbit/utils/object-values';
 
 export default Ember.Object.extend({
   _orbitCache: null,
@@ -51,8 +52,8 @@ export default Ember.Object.extend({
 
     switch(query.expression.op) {
       case 'record':        return this._identityMap.lookup(result);
-      case 'recordsOfType': return this._identityMap.lookupMany(Object.values(result));
-      case 'filter':        return this._identityMap.lookupMany(Object.values(result));
+      case 'recordsOfType': return this._identityMap.lookupMany(objectValues(result));
+      case 'filter':        return this._identityMap.lookupMany(objectValues(result));
       default:              return result;
     }
   },

--- a/addon/store.js
+++ b/addon/store.js
@@ -2,6 +2,7 @@ import Cache from 'ember-orbit/cache';
 import IdentityMap from 'ember-orbit/identity-map';
 import OrbitStore from 'orbit-common/store';
 import Query from 'orbit/query';
+import objectValues from 'ember-orbit/utils/object-values';
 
 /**
  @module ember-orbit
@@ -48,8 +49,8 @@ export default Ember.Object.extend({
       .then(result => {
         switch(query.expression.op) {
           case 'record':        return this._identityMap.lookup(result);
-          case 'recordsOfType': return this._identityMap.lookupMany(Object.values(result));
-          case 'filter':        return this._identityMap.lookupMany(Object.values(result));
+          case 'recordsOfType': return this._identityMap.lookupMany(objectValues(result));
+          case 'filter':        return this._identityMap.lookupMany(objectValues(result));
           default:              return result;
         }
       });

--- a/addon/utils/object-values.js
+++ b/addon/utils/object-values.js
@@ -1,0 +1,6 @@
+function objectValues(object) {
+  return Object.keys(object).map(k => object[k]);
+}
+
+let implementation = Object.values || objectValues;
+export default implementation;

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,9 +4,6 @@ var EmberApp = require('ember-cli/lib/broccoli/ember-addon');
 module.exports = function(defaults) {
   var app = new EmberApp(defaults, {
     // Add options here
-    babel: {
-      includePolyfill: true
-    }
   });
 
   /*

--- a/index.js
+++ b/index.js
@@ -92,10 +92,6 @@ module.exports = {
   included: function(app) {
     app.import('vendor/immutable/dist/immutable.min.js');
 
-    app.options = app.options || {};
-    app.options.babel = app.options.babel || {};
-    app.options.babel.includePolyfill = true;
-
     return this._super.included(app);
   }
 };


### PR DESCRIPTION
Turning on all Babel polyfills in a host application or even adding a global polyfill seems a little intrusive. On top of that, the current approach doesn't seem to work out of the box for me in an Ember CLI app. 

Would you be open to a more conservative approach like this?

`Object.keys` looks like it's safe to use as it is supported in IE 9 and up.