### PR TITLE
Revert "Introduce async/await style tests"

### DIFF
--- a/tests/integration/store-test.js
+++ b/tests/integration/store-test.js
@@ -16,66 +16,118 @@ module('Integration - Store', function(hooks) {
     store = null;
   });
 
-  test('#addRecord', async assert => {
-    const planet = await store.addRecord({ type: 'planet', name: 'Earth' });
-    assert.ok(planet instanceof Planet);
-    assert.ok(get(planet, 'id'), 'assigned id');
-    assert.equal(get(planet, 'name'), 'Earth');
+  test('#addRecord', function(assert) {
+    return store.addRecord({ type: 'planet', name: 'Earth' })
+      .then(function(planet) {
+         assert.ok(planet instanceof Planet);
+         assert.ok(get(planet, 'id'), 'assigned id');
+         assert.equal(get(planet, 'name'), 'Earth');
+      });
   });
 
-  test('#findRecord', async assert => {
-    const record = await store.addRecord({ type: 'planet', name: 'Earth' });
-    const planet = await store.findRecord('planet', record.get('id'));
-    assert.ok(planet instanceof Planet);
-    assert.ok(get(planet, 'id'), 'assigned id');
-    assert.equal(get(planet, 'name'), 'Earth');
+  test('#findRecord', function(assert) {
+    return store.addRecord({ type: 'planet', name: 'Earth' })
+      .then( record => store.findRecord('planet', record.get('id')))
+      .then( planet => {
+        assert.ok(planet instanceof Planet);
+        assert.ok(get(planet, 'id'), 'assigned id');
+        assert.equal(get(planet, 'name'), 'Earth');
+      });
   });
 
-  test('#removeRecord', async assert => {
-    const record = await store.addRecord({ type: 'planet', name: 'Earth' });
-    await store.removeRecord(record);
-
-    try {
-      await store.findRecord('planet', record.get('id'));
-    }
-    catch(error) {
-      assert.ok(error.message.match(/Record not found/));
-    }
+  test('#removeRecord', function(assert) {
+    return store.addRecord({ type: 'planet', name: 'Earth' })
+      .tap(record => store.removeRecord(record))
+      .then(record => store.findRecord('planet', record.get('id')))
+      .catch(error => {
+        assert.ok(error.message.match(/Record not found/));
+      });
   });
 
-  test('#query - record', async assert => {
-    const earth = await store.addRecord({ type: 'planet', name: 'Earth' });
-    const record = await store.query(q => q.record(earth));
-    assert.strictEqual(record, earth);
+  test('#query - record', function(assert) {
+    let earth;
+
+    return store.addRecord({ type: 'planet', name: 'Earth' })
+      .then(record => {
+        earth = record;
+        return store.addRecord({ type: 'planet', name: 'Jupiter' });
+      })
+      .then(() => {
+        return store.query(q => q.record(earth));
+      })
+      .then(record => {
+        assert.strictEqual(record, earth);
+      });
   });
 
-  test('#query - recordsOfType', async assert => {
-    const earth = await store.addRecord({ type: 'planet', name: 'Earth' });
-    const jupiter = await store.addRecord({ type: 'planet', name: 'Jupiter' });
-    const records = await store.query(q => q.recordsOfType('planet'));
-    assert.deepEqual(records, [earth, jupiter]);
-    assert.strictEqual(records[0], earth);
-    assert.strictEqual(records[1], jupiter);
+  test('#query - recordsOfType', function(assert) {
+    let earth, jupiter;
+
+    return store.addRecord({ type: 'planet', name: 'Earth' })
+      .then(record => {
+        earth = record;
+        return store.addRecord({ type: 'planet', name: 'Jupiter' });
+      })
+      .then(record => {
+        jupiter = record;
+        return store.query(q => q.recordsOfType('planet'));
+      })
+      .then(records => {
+        assert.deepEqual(records, [earth, jupiter]);
+        assert.strictEqual(records[0], earth);
+        assert.strictEqual(records[1], jupiter);
+      });
   });
 
-  test('#query - filter', async assert => {
-    const earth = await store.addRecord({ type: 'planet', name: 'Earth' });
-    const records = await store.query(q => q.recordsOfType('planet').filterAttributes({ name: 'Earth' }));
-    assert.deepEqual(records, [earth]);
-    assert.strictEqual(records[0], earth);
+  test('#query - filter', function(assert) {
+    let earth;
+
+    return store.addRecord({ type: 'planet', name: 'Earth' })
+      .then(record => {
+        earth = record;
+        return store.addRecord({ type: 'planet', name: 'Jupiter' });
+      })
+      .then(() => {
+        return store.query(q => q.recordsOfType('planet').filterAttributes({ name: 'Earth' }));
+      })
+      .then(records => {
+        assert.deepEqual(records, [earth]);
+        assert.strictEqual(records[0], earth);
+      });
   });
 
-  test('#find - by type and id', async assert => {
-    const earth = await store.addRecord({ type: 'planet', name: 'Earth' });
-    const record = await store.find('planet', earth.id);
-    assert.strictEqual(record, earth);
+  test('#find - by type and id', function(assert) {
+    let earth;
+
+    return store.addRecord({ type: 'planet', name: 'Earth' })
+      .then(record => {
+        earth = record;
+        return store.addRecord({ type: 'planet', name: 'Jupiter' });
+      })
+      .then(() => {
+        return store.find('planet', earth.id);
+      })
+      .then(record => {
+        assert.strictEqual(record, earth);
+      });
   });
 
-  test('#find - by type', async assert => {
-    const earth = await store.addRecord({ type: 'planet', name: 'Earth' });
-    const jupiter = await store.addRecord({ type: 'planet', name: 'Jupiter' });
-    const records = await store.find('planet');
-    assert.strictEqual(records[0], earth);
-    assert.strictEqual(records[1], jupiter);
+  test('#find - by type', function(assert) {
+    let earth, jupiter;
+
+    return store.addRecord({ type: 'planet', name: 'Earth' })
+      .then(record => {
+        earth = record;
+        return store.addRecord({ type: 'planet', name: 'Jupiter' });
+      })
+      .then(record => {
+        jupiter = record;
+        return store.find('planet');
+      })
+      .then(records => {
+        assert.deepEqual(records, [earth, jupiter]);
+        assert.strictEqual(records[0], earth);
+        assert.strictEqual(records[1], jupiter);
+      });
   });
 });


### PR DESCRIPTION
This reverts commit 52aaa2137cbc928a0b53eae0863a14ba4cfc592c.

Use of async/await requires inclusion of the babel polyfill. As this would force apps to also include the polyfill this PR backs out the usage of async/await.