### PR TITLE
Update for compatibility with latest Orbit.

### DIFF
--- a/addon/cache.js
+++ b/addon/cache.js
@@ -51,10 +51,10 @@ export default Ember.Object.extend({
     const result = this._orbitCache.query(query);
 
     switch(query.expression.op) {
-      case 'record':        return this._identityMap.lookup(result);
-      case 'recordsOfType': return this._identityMap.lookupMany(objectValues(result));
-      case 'filter':        return this._identityMap.lookupMany(objectValues(result));
-      default:              return result;
+      case 'record':  return this._identityMap.lookup(result);
+      case 'records': return this._identityMap.lookupMany(objectValues(result));
+      case 'filter':  return this._identityMap.lookupMany(objectValues(result));
+      default:        return result;
     }
   },
 

--- a/addon/model.js
+++ b/addon/model.js
@@ -1,5 +1,10 @@
 import HasMany from './relationships/has-many';
 import { uuid } from 'orbit/lib/uuid';
+import {
+  replaceKey,
+  replaceAttribute,
+  replaceHasOne
+} from 'orbit-common/transform/operators';
 
 /**
  @module ember-orbit
@@ -24,7 +29,7 @@ const Model = Ember.Object.extend(Ember.Evented, {
 
   replaceKey(field, value) {
     const store = get(this, '_storeOrError');
-    store.update(t => t.replaceKey(this, field, value));
+    store.update(replaceKey(this, field, value));
   },
 
   getAttribute(field) {
@@ -34,7 +39,7 @@ const Model = Ember.Object.extend(Ember.Evented, {
 
   replaceAttribute(attribute, value) {
     const store = get(this, '_storeOrError');
-    store.update(t => t.replaceAttribute(this, attribute, value));
+    store.update(replaceAttribute(this, attribute, value));
   },
 
   getHasOne(relationship) {
@@ -44,7 +49,7 @@ const Model = Ember.Object.extend(Ember.Evented, {
 
   replaceHasOne(relationship, record) {
     const store = get(this, '_storeOrError');
-    store.update(t => t.replaceHasOne(this, relationship, record));
+    store.update(replaceHasOne(this, relationship, record));
   },
 
   getHasMany(field) {

--- a/addon/relationships/has-many.js
+++ b/addon/relationships/has-many.js
@@ -1,6 +1,10 @@
 import Ember from 'ember';
 import LiveQuery from '../live-query';
 import qb from 'orbit-common/query/builder';
+import {
+  addToHasMany,
+  removeFromHasMany
+} from 'orbit-common/transform/operators';
 
 const { get } = Ember;
 
@@ -28,7 +32,7 @@ export default LiveQuery.extend({
 
     // console.log('pushObject', model.type, model.id, relationship, record.type, record.id);
 
-    return store.update(t => t.addToHasMany(model, relationship, record));
+    return store.update(addToHasMany(model, relationship, record));
   },
 
   removeObject(record) {
@@ -36,6 +40,6 @@ export default LiveQuery.extend({
     const model = this.get('_model');
     const relationship = this.get('_relationship');
 
-    return store.update(t => t.removeFromHasMany(model, relationship, record));
+    return store.update(removeFromHasMany(model, relationship, record));
   }
 });

--- a/addon/store.js
+++ b/addon/store.js
@@ -38,7 +38,7 @@ export default Ember.Object.extend({
 
   find(type, id) {
     if (id === undefined) {
-      return this.query(qb.recordsOfType(type));
+      return this.query(qb.records(type));
     } else {
       return this.query(qb.record({type, id}));
     }
@@ -49,10 +49,10 @@ export default Ember.Object.extend({
     return this.orbitStore.query(query)
       .then(result => {
         switch(query.expression.op) {
-          case 'record':        return this._identityMap.lookup(result);
-          case 'recordsOfType': return this._identityMap.lookupMany(objectValues(result));
-          case 'filter':        return this._identityMap.lookupMany(objectValues(result));
-          default:              return result;
+          case 'record':  return this._identityMap.lookup(result);
+          case 'records': return this._identityMap.lookupMany(objectValues(result));
+          case 'filter':  return this._identityMap.lookupMany(objectValues(result));
+          default:        return result;
         }
       });
   },

--- a/addon/store.js
+++ b/addon/store.js
@@ -4,6 +4,10 @@ import OrbitStore from 'orbit-common/store';
 import Query from 'orbit/query';
 import objectValues from 'ember-orbit/utils/object-values';
 import qb from 'orbit-common/query/builder';
+import {
+  addRecord,
+  removeRecord
+} from 'orbit-common/transform/operators';
 
 /**
  @module ember-orbit
@@ -65,7 +69,7 @@ export default Ember.Object.extend({
     this._verifyType(properties.type);
 
     const record = this.schema.normalize(properties);
-    return this.update(t => t.addRecord(record))
+    return this.update(addRecord(record))
       .then(() => this._identityMap.lookup(record));
   },
 
@@ -74,7 +78,7 @@ export default Ember.Object.extend({
   },
 
   removeRecord(record) {
-    return this.update(t => t.removeRecord(record));
+    return this.update(removeRecord(record));
   },
 
   _verifyType(type) {

--- a/tests/integration/cache-test.js
+++ b/tests/integration/cache-test.js
@@ -29,7 +29,7 @@ module('Integration - Cache', function(hooks) {
 
   test('liveQuery - adds record that becomes a match', function(assert) {
     store.addRecord({ id: 'jupiter', type: 'planet', attributes: { name: 'Jupiter2' } });
-    const liveQuery = cache.liveQuery(qb.recordsOfType('planet')
+    const liveQuery = cache.liveQuery(qb.records('planet')
                                         .filterAttributes({ name: 'Jupiter' }));
 
     return store.update(t => t.replaceAttribute({ type: 'planet', id: 'jupiter' }, 'name', 'Jupiter'))
@@ -39,7 +39,7 @@ module('Integration - Cache', function(hooks) {
   });
 
   test('liveQuery - updates when matching record is added', function(assert) {
-    const planets = cache.liveQuery(oqe('recordsOfType', 'planet'));
+    const planets = cache.liveQuery(oqe('records', 'planet'));
     const addJupiter = store.addRecord({ id: 'jupiter', type: 'planet', name: 'Jupiter' });
     return addJupiter.then(jupiter => assert.ok(planets.contains(jupiter)));
   });
@@ -48,7 +48,7 @@ module('Integration - Cache', function(hooks) {
     const done = assert.async();
 
     Ember.run(() => {
-      const planets = cache.liveQuery(oqe('recordsOfType', 'planet'));
+      const planets = cache.liveQuery(oqe('records', 'planet'));
 
       store
         .addRecord({type: 'planet', name: 'Jupiter'})
@@ -62,7 +62,7 @@ module('Integration - Cache', function(hooks) {
     const done = assert.async();
 
     Ember.run(() => {
-      const planets = cache.liveQuery(oqe('recordsOfType', 'planet'));
+      const planets = cache.liveQuery(oqe('records', 'planet'));
 
       store
         .addRecord({type: 'moon', name: 'Callisto'})
@@ -75,7 +75,7 @@ module('Integration - Cache', function(hooks) {
     const done = assert.async();
 
     Ember.run(() => {
-      const planets = cache.liveQuery(qb.recordsOfType('planet'));
+      const planets = cache.liveQuery(qb.records('planet'));
 
       store
         .update(t => {
@@ -97,7 +97,7 @@ module('Integration - Cache', function(hooks) {
     Ember.run(() => {
       const planets = cache.liveQuery(
         oqe('filter',
-          oqe('recordsOfType', 'planet'),
+          oqe('records', 'planet'),
           oqe('equal', oqe('attribute', 'name'), 'Jupiter')));
 
       store
@@ -178,7 +178,7 @@ module('Integration - Cache', function(hooks) {
       });
   });
 
-  test('#query - recordsOfType', function(assert) {
+  test('#query - records', function(assert) {
     let earth, jupiter;
 
     return store.addRecord({ type: 'planet', name: 'Earth' })
@@ -189,7 +189,7 @@ module('Integration - Cache', function(hooks) {
       .then(record => {
         jupiter = record;
 
-        const foundRecords = cache.query(qb.recordsOfType('planet'));
+        const foundRecords = cache.query(qb.records('planet'));
         assert.deepEqual(foundRecords, [earth, jupiter]);
         assert.strictEqual(foundRecords[0], earth);
         assert.strictEqual(foundRecords[1], jupiter);
@@ -205,7 +205,7 @@ module('Integration - Cache', function(hooks) {
         return store.addRecord({ type: 'planet', name: 'Jupiter' });
       })
       .then(() => {
-        const foundRecords = cache.query(qb.recordsOfType('planet').filterAttributes({ name: 'Earth' }));
+        const foundRecords = cache.query(qb.records('planet').filterAttributes({ name: 'Earth' }));
         assert.deepEqual(foundRecords, [earth]);
         assert.strictEqual(foundRecords[0], earth);
       });

--- a/tests/integration/store-test.js
+++ b/tests/integration/store-test.js
@@ -61,7 +61,7 @@ module('Integration - Store', function(hooks) {
       });
   });
 
-  test('#query - recordsOfType', function(assert) {
+  test('#query - records', function(assert) {
     let earth, jupiter;
 
     return store.addRecord({ type: 'planet', name: 'Earth' })
@@ -71,7 +71,7 @@ module('Integration - Store', function(hooks) {
       })
       .then(record => {
         jupiter = record;
-        return store.query(qb.recordsOfType('planet'));
+        return store.query(qb.records('planet'));
       })
       .then(records => {
         assert.deepEqual(records, [earth, jupiter]);
@@ -89,7 +89,7 @@ module('Integration - Store', function(hooks) {
         return store.addRecord({ type: 'planet', name: 'Jupiter' });
       })
       .then(() => {
-        return store.query(qb.recordsOfType('planet').filterAttributes({ name: 'Earth' }));
+        return store.query(qb.records('planet').filterAttributes({ name: 'Earth' }));
       })
       .then(records => {
         assert.deepEqual(records, [earth]);


### PR DESCRIPTION
* refactor query operator `recordsOfType` => `records`.
* eliminate usage of `TransformBuilder` in favor of calling transform operator fns directly.