### PR TITLE
Replace ember-ajax with ember-network.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "devDependencies": {
     "babel-eslint": "^6.1.0",
     "broccoli-asset-rev": "^2.4.2",
-    "ember-ajax": "^2.0.1",
     "ember-cli": "2.6.2",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
@@ -54,6 +53,7 @@
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
+    "ember-network": "^0.3.0",
     "ember-resolver": "^2.0.3",
     "eslint": "^2.11.0",
     "loader.js": "^4.0.1"


### PR DESCRIPTION
Orbit’s JSONAPISource now uses fetch instead of jQuery.ajax.