### PR TITLE
Fix use of ember-network/fetch.

### DIFF
--- a/addon/initializers/ember-orbit.js
+++ b/addon/initializers/ember-orbit.js
@@ -2,9 +2,11 @@ import Ember from 'ember';
 import Orbit from 'orbit';
 import Store from 'ember-orbit/store';
 import Schema from 'ember-orbit/schema';
+import fetch from 'ember-network/fetch';
 
 export function initialize(application) {
   Orbit.Promise = Ember.RSVP.Promise;
+  Orbit.fetch = fetch;
 
   application.register('schema:main', Schema);
   application.register('service:store', Store);

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
-    "ember-network": "^0.3.0",
     "ember-resolver": "^2.0.3",
     "eslint": "^2.11.0",
     "loader.js": "^4.0.1"
@@ -73,6 +72,7 @@
     "broccoli-merge-trees": "^1.1.1",
     "broccoli-replace": "^0.12.0",
     "ember-cli-babel": "^5.1.6",
+    "ember-network": "^0.3.0",
     "immutable": "^3.8.1",
     "rxjs-es": "5.0.0-beta.8",
     "orbit.js": "git://github.com/orbitjs/orbit.js#master",


### PR DESCRIPTION
Orbit now supports use of `fetch` ponyfills via setting `Orbit.fetch`.
ember-orbit now directly uses the `ember-network/fetch` ponyfill, which
in turn requires `ember-network` to be a full dependency (not just a dev
dependency).

Thanks to @mitchlloyd for raising this in
https://github.com/orbitjs/ember-orbit/pull/118#issuecomment-236463642