### PR TITLE
Include standard Orbit sources for ease of use.

### DIFF
--- a/addon/initializers/ember-orbit.js
+++ b/addon/initializers/ember-orbit.js
@@ -2,9 +2,11 @@ import Ember from 'ember';
 import Orbit from 'orbit';
 import Store from 'ember-orbit/store';
 import Schema from 'ember-orbit/schema';
+import fetch from 'ember-network/fetch';
 
 export function initialize(application) {
   Orbit.Promise = Ember.RSVP.Promise;
+  Orbit.fetch = fetch;
 
   application.register('schema:main', Schema);
   application.register('service:store', Store);

--- a/index.js
+++ b/index.js
@@ -6,23 +6,14 @@ var Funnel     = require('broccoli-funnel');
 var MergeTrees = require('broccoli-merge-trees');
 var path = require('path');
 
+function packageSource(pkg, namespace) {
+  return new Funnel(path.join(require.resolve(pkg), '..'), {
+    include: ['**/*.js'],
+    destDir: './' + (namespace || pkg)
+  });
+}
+
 var modules = {
-  orbit: function() {
-    var orbitSrc = path.join(require.resolve('orbit-core'), '..');
-    return new Funnel(orbitSrc, {
-      include: ['**/*.js'],
-      destDir: './orbit'
-    });
-  },
-
-  rxjs: function() {
-    var rxjsSource = path.join(require.resolve('rxjs-es'), '..');
-    return new Funnel(rxjsSource, {
-      include: ['**/*.js'],
-      destDir: './rxjs'
-    });
-  },
-
   symbolObservable: function() {
     var rxjsPath = path.join(require.resolve('rxjs-es'), '..');
     var symbolObservablePath = path.join(rxjsPath, 'node_modules', 'symbol-observable', 'es');
@@ -37,8 +28,10 @@ var modules = {
 
   index: function() {
     return MergeTrees([
-      modules.rxjs(),
-      modules.orbit(),
+      packageSource('rxjs-es', 'rxjs'),
+      packageSource('orbit-core', 'orbit'),
+      packageSource('orbit-jsonapi'),
+      packageSource('orbit-local-storage'),
       modules.symbolObservable()
     ]);
   }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
+    "ember-network": "0.3.0",
     "ember-resolver": "^2.0.3",
     "eslint": "^2.11.0",
     "loader.js": "^4.0.1"
@@ -54,6 +55,8 @@
     "ember-cli-babel": "^5.1.6",
     "immutable": "^3.8.1",
     "orbit-core": "^0.8.0-beta.2",
+    "orbit-jsonapi": "^0.8.0-beta.2",
+    "orbit-local-storage": "^0.8.0-beta.1",
     "rxjs-es": "^5.0.0-beta.11"
   },
   "ember-addon": {


### PR DESCRIPTION
These sources should be removed eventually from the base
ember-orbit, but for now it provides a simpler onboarding 
experience for developers (instead of custom tree-merging).