### PR TITLE
Use options to allow parents to specify orbit sources.

### DIFF
--- a/addon/initializers/ember-orbit.js
+++ b/addon/initializers/ember-orbit.js
@@ -2,11 +2,9 @@ import Ember from 'ember';
 import Orbit from 'orbit';
 import Store from 'ember-orbit/store';
 import Schema from 'ember-orbit/schema';
-import fetch from 'ember-network/fetch';
 
 export function initialize(application) {
   Orbit.Promise = Ember.RSVP.Promise;
-  Orbit.fetch = fetch;
 
   application.register('schema:main', Schema);
   application.register('service:store', Store);

--- a/package.json
+++ b/package.json
@@ -52,11 +52,9 @@
     "broccoli-merge-trees": "^1.1.1",
     "broccoli-replace": "^0.12.0",
     "ember-cli-babel": "^5.1.6",
-    "ember-network": "0.3.0",
     "immutable": "^3.8.1",
     "orbit-core": "^0.8.0-beta.2",
-    "orbit-jsonapi": "^0.8.0-beta.2",
-    "orbit-local-storage": "^0.8.0-beta.1",
+    "resolve": "^1.1.7",
     "rxjs-es": "^5.0.0-beta.11"
   },
   "ember-addon": {


### PR DESCRIPTION
This allows us to remove the ancillary packages:
* ember-network
* orbit-jsonapi
* orbit-local-storage

These are more appropriately configured in parent apps as needed.