### PR TITLE
Introduce Model#identity.

### DIFF
--- a/addon/model.js
+++ b/addon/model.js
@@ -20,36 +20,42 @@ const Model = Ember.Object.extend(Ember.Evented, {
   id: null,
   type: null,
   _store: null,
+
+  init() {
+    this._super();
+    this.identity = { id: this.id, type: this.type };
+  },
+
   disconnected: Ember.computed.empty('_store'),
 
   getKey(field) {
     const cache = get(this, '_storeOrError.cache');
-    return cache.retrieveKey(this, field);
+    return cache.retrieveKey(this.identity, field);
   },
 
   replaceKey(field, value) {
     const store = get(this, '_storeOrError');
-    store.update(replaceKey(this, field, value));
+    store.update(replaceKey(this.identity, field, value));
   },
 
   getAttribute(field) {
     const cache = get(this, '_storeOrError.cache');
-    return cache.retrieveAttribute(this, field);
+    return cache.retrieveAttribute(this.identity, field);
   },
 
   replaceAttribute(attribute, value) {
     const store = get(this, '_storeOrError');
-    store.update(replaceAttribute(this, attribute, value));
+    store.update(replaceAttribute(this.identity, attribute, value));
   },
 
   getHasOne(relationship) {
     const cache = get(this, '_storeOrError.cache');
-    return cache.retrieveHasOne(this, relationship);
+    return cache.retrieveHasOne(this.identity, relationship);
   },
 
   replaceHasOne(relationship, record) {
     const store = get(this, '_storeOrError');
-    store.update(replaceHasOne(this, relationship, record));
+    store.update(replaceHasOne(this.identity, relationship, record));
   },
 
   getHasMany(field) {

--- a/addon/relationships/has-many.js
+++ b/addon/relationships/has-many.js
@@ -32,7 +32,7 @@ export default LiveQuery.extend({
 
     // console.log('pushObject', model.type, model.id, relationship, record.type, record.id);
 
-    return store.update(addToHasMany(model, relationship, record));
+    return store.update(addToHasMany(model.identity, relationship, record.identity));
   },
 
   removeObject(record) {
@@ -40,6 +40,6 @@ export default LiveQuery.extend({
     const model = this.get('_model');
     const relationship = this.get('_relationship');
 
-    return store.update(removeFromHasMany(model, relationship, record));
+    return store.update(removeFromHasMany(model.identity, relationship, record.identity));
   }
 });

--- a/tests/integration/model-test.js
+++ b/tests/integration/model-test.js
@@ -28,6 +28,7 @@ module('Integration - Model', function(hooks) {
           .addRecord({type: 'planet', galaxyAlias: 'planet:jupiter', name: 'Jupiter', star: theSun, moons: [callisto]})
           .then(record => {
             assert.ok(record.get('id'), 'assigned id');
+            assert.deepEqual(record.get('identity'), { id: record.get('id'), type: 'planet' }, 'assigned identity that includes type and id');
             assert.equal(record.get('name'), 'Jupiter', 'assigned specified attribute');
             assert.equal(record.get('atmosphere'), false, 'assigned default value for unspecified attribute');
             assert.equal(record.get('galaxyAlias'), 'planet:jupiter', 'assigned secondary key');


### PR DESCRIPTION
An Orbit `identity` is a POJO containing a record’s `id` and `type`.
We should use this simple object in Orbit operations instead of passing
around full EmberOrbit model instances.