### PR TITLE
Fix relatedRecord and relatedRecords queries.

### DIFF
--- a/addon/store.js
+++ b/addon/store.js
@@ -85,10 +85,15 @@ const Store = Ember.Object.extend({
     return this.orbitStore.query(query)
       .then(result => {
         switch(query.expression.op) {
-          case 'record':  return this._identityMap.lookup(result);
-          case 'records': return this._identityMap.lookupMany(objectValues(result));
-          case 'filter':  return this._identityMap.lookupMany(objectValues(result));
-          default:        return result;
+          case 'record':
+          case 'relatedRecord':
+            return this._identityMap.lookup(result);
+          case 'records':
+          case 'relatedRecords':
+          case 'filter':
+            return this._identityMap.lookupMany(objectValues(result));
+          default:
+            return result;
         }
       });
   },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "ember-cli-babel": "^5.1.6",
     "immutable": "^3.8.1",
     "orbit-core": "^0.8.0-beta.4",
-    "orbit-store": "^0.8.0-beta.2",
+    "orbit-store": "^0.8.0-beta.3",
     "resolve": "^1.1.7",
     "rxjs-es": "^5.0.0-beta.11"
   },

--- a/tests/integration/model-test.js
+++ b/tests/integration/model-test.js
@@ -16,97 +16,67 @@ module('Integration - Model', function(hooks) {
   });
 
   test('add new model', function(assert) {
-    Ember.run(() => {
-      const done = assert.async();
-
-      Ember.RSVP.Promise.all([
-        store.addRecord({type: 'star', name: 'The Sun'}),
-        store.addRecord({type: 'moon', name: 'Callisto'})
-      ])
+    return Ember.RSVP.Promise.all([
+      store.addRecord({type: 'star', name: 'The Sun'}),
+      store.addRecord({type: 'moon', name: 'Callisto'})
+    ])
       .then(([theSun, callisto]) => {
         store
-          .addRecord({type: 'planet', galaxyAlias: 'planet:jupiter', name: 'Jupiter', star: theSun, moons: [callisto]})
+          .addRecord({type: 'planet', galaxyAlias: 'planet:jupiter', name: 'Jupiter', sun: theSun, moons: [callisto]})
           .then(record => {
             assert.ok(record.get('id'), 'assigned id');
             assert.deepEqual(record.get('identity'), { id: record.get('id'), type: 'planet' }, 'assigned identity that includes type and id');
             assert.equal(record.get('name'), 'Jupiter', 'assigned specified attribute');
             assert.equal(record.get('atmosphere'), false, 'assigned default value for unspecified attribute');
             assert.equal(record.get('galaxyAlias'), 'planet:jupiter', 'assigned secondary key');
-            // assert.equal(record.get('star'), theSun, 'assigned hasOne');
-            // assert.deepEqual(record.get('moons.firstObject'), callisto, 'assigned hasMany');
-            done();
+            assert.strictEqual(record.get('sun'), theSun, 'assigned hasOne');
+            assert.strictEqual(record.get('moons.firstObject'), callisto, 'assigned hasMany');
           });
       });
-    });
   });
 
   test('remove model', function(assert) {
-    Ember.run(() => {
-      const done = assert.async();
-      const cache = store.get('cache');
+    const cache = store.get('cache');
 
-      store
-        .addRecord({type: 'star', name: 'The Sun'})
-        .tap(record => record.remove())
-        .then(record => {
-          assert.ok(!cache.retrieve(['star', record.get('id')]));
-          assert.ok(record.get('disconnected'), 'record has been disconnected from store');
-          assert.throws(() => record.get('name'), Ember.Error, 'record has been removed from Store');
-        })
-        .then(done);
-    });
+    return store.addRecord({type: 'star', name: 'The Sun'})
+      .tap(record => record.remove())
+      .then(record => {
+        assert.ok(!cache.retrieve(['star', record.get('id')]), 'record does not exist in cache');
+        assert.ok(record.get('disconnected'), 'record has been disconnected from store');
+        assert.throws(() => record.get('name'), Ember.Error, 'record has been removed from Store');
+      });
   });
 
   test('add to hasMany', function(assert) {
-    Ember.run(() => {
-      const done = assert.async();
-
-      Ember.RSVP.Promise.all([
-        store.addRecord({type: 'planet', name: 'Jupiter'}),
-        store.addRecord({type: 'moon', name: 'Callisto'})
-      ])
-      .tap(([jupiter, callisto]) => {
-        return jupiter.get('moons').pushObject(callisto);
-        // console.debug('pushed');
-        // return [jupiter, callisto];
-      })
+    return Ember.RSVP.Promise.all([
+      store.addRecord({type: 'planet', name: 'Jupiter'}),
+      store.addRecord({type: 'moon', name: 'Callisto'})
+    ])
+      .tap(([jupiter, callisto]) => jupiter.get('moons').pushObject(callisto))
       .then(([jupiter, callisto]) => {
-        // console.debug('asserting');
         assert.ok(jupiter.get('moons').contains(callisto), 'added record to hasMany');
         assert.equal(callisto.get('planet'), jupiter, 'updated inverse');
-        done();
       });
-    });
   });
 
   test('remove from hasMany', function(assert) {
-    Ember.run(() => {
-      const done = assert.async();
-
-      Ember.RSVP.Promise.all([
-        store.addRecord({type: 'planet', name: 'Jupiter'}),
-        store.addRecord({type: 'moon', name: 'Callisto'})
-      ])
+    return Ember.RSVP.Promise.all([
+      store.addRecord({type: 'planet', name: 'Jupiter'}),
+      store.addRecord({type: 'moon', name: 'Callisto'})
+    ])
       .tap(([jupiter, callisto]) => jupiter.get('moons').pushObject(callisto))
-      .tap(([jupiter, callisto]) => {
-        return jupiter.get('moons').removeObject(callisto);
-      })
+      .tap(([jupiter, callisto]) => jupiter.get('moons').removeObject(callisto))
       .then(([jupiter, callisto]) => {
         assert.ok(!jupiter.get('moons').contains(callisto), 'removed record from hasMany');
         assert.ok(!callisto.get('planet'), 'updated inverse');
-        done();
       });
-    });
   });
 
   test('replace hasOne with record', function(assert) {
-    Ember.run(() => {
-      const done = assert.async();
-
-      Ember.RSVP.Promise.all([
-        store.addRecord({type: 'planet', name: 'Jupiter'}),
-        store.addRecord({type: 'moon', name: 'Callisto'})
-      ])
+    return Ember.RSVP.Promise.all([
+      store.addRecord({type: 'planet', name: 'Jupiter'}),
+      store.addRecord({type: 'moon', name: 'Callisto'})
+    ])
       .tap(([jupiter, callisto]) => {
         callisto.set('planet', jupiter);
         return store.requestQueue.process();
@@ -114,19 +84,14 @@ module('Integration - Model', function(hooks) {
       .then(([jupiter, callisto]) => {
         assert.equal(callisto.get('planet'), jupiter, 'replaced hasOne with record');
         assert.ok(jupiter.get('moons').contains(callisto), 'updated inverse');
-        done();
       });
-    });
   });
 
   test('replace hasOne with null', function(assert) {
-    Ember.run(() => {
-      const done = assert.async();
-
-      Ember.RSVP.Promise.all([
-        store.addRecord({type: 'planet', name: 'Jupiter'}),
-        store.addRecord({type: 'moon', name: 'Callisto'})
-      ])
+    return Ember.RSVP.Promise.all([
+      store.addRecord({type: 'planet', name: 'Jupiter'}),
+      store.addRecord({type: 'moon', name: 'Callisto'})
+    ])
       .tap(([jupiter, callisto]) => {
         callisto.set('planet', jupiter);
         return store.requestQueue.process();
@@ -138,48 +103,29 @@ module('Integration - Model', function(hooks) {
       .then(([jupiter, callisto]) => {
         assert.equal(callisto.get('planet'), null, 'replaced hasOne with null');
         assert.ok(!jupiter.get('moons').contains(callisto), 'removed from inverse hasMany');
-        done();
       });
-    });
   });
 
   test('replace attribute on model', function(assert) {
-    Ember.run(() => {
-      const done = assert.async();
-
-      store
-        .addRecord({type: 'planet', name: 'Jupiter'})
-        .tap(record => record.set('name', 'Jupiter2'))
-        .then(record => assert.equal(record.get('name'), 'Jupiter2'))
-        .then(done);
-    });
+    return store.addRecord({type: 'planet', name: 'Jupiter'})
+      .tap(record => record.set('name', 'Jupiter2'))
+      .then(record => assert.equal(record.get('name'), 'Jupiter2'));
   });
 
   test('replace key', function(assert) {
-    Ember.run(() => {
-      const done = assert.async();
-
-      store
-        .addRecord({type: 'planet', name: 'Jupiter', galaxyAlias: 'planet:jupiter'})
-        .tap(record => record.set('galaxyAlias', 'planet:joopiter'))
-        .then(record => assert.equal(record.get('galaxyAlias'), 'planet:joopiter'))
-        .then(done);
-    });
+    return store.addRecord({type: 'planet', name: 'Jupiter', galaxyAlias: 'planet:jupiter'})
+      .tap(record => record.set('galaxyAlias', 'planet:joopiter'))
+      .then(record => assert.equal(record.get('galaxyAlias'), 'planet:joopiter'));
   });
 
   test('destroy model', function(assert) {
-    Ember.run(() => {
-      const done = assert.async();
-      const cache = store.get('cache');
+    const cache = store.get('cache');
 
-      store
-        .addRecord({type: 'planet', name: 'Jupiter'})
-        .tap(record => record.destroy())
-        .then(record => {
-          const identifier = record.getProperties('type', 'id');
-          assert.ok(!cache.get('_identityMap').contains(identifier), 'removed from identity map');
-        })
-        .then(done);
-    });
+    return store.addRecord({type: 'planet', name: 'Jupiter'})
+      .tap(record => record.destroy())
+      .then(record => {
+        const identifier = record.getProperties('type', 'id');
+        assert.ok(!cache.get('_identityMap').contains(identifier), 'removed from identity map');
+      });
   });
 });

--- a/tests/integration/store-test.js
+++ b/tests/integration/store-test.js
@@ -58,12 +58,11 @@ module('Integration - Store', function(hooks) {
   test('#query - record', function(assert) {
     let earth;
 
-    return store.addRecord({ type: 'planet', name: 'Earth' })
-      .then(record => {
-        earth = record;
-        return store.addRecord({ type: 'planet', name: 'Jupiter' });
-      })
-      .then(() => {
+    return Ember.RSVP.Promise.all([
+      store.addRecord({ type: 'planet', name: 'Earth' })
+    ])
+      .then(([result1]) => {
+        earth = result1;
         return store.query(qb.record(earth));
       })
       .then(record => {
@@ -74,13 +73,13 @@ module('Integration - Store', function(hooks) {
   test('#query - records', function(assert) {
     let earth, jupiter;
 
-    return store.addRecord({ type: 'planet', name: 'Earth' })
-      .then(record => {
-        earth = record;
-        return store.addRecord({ type: 'planet', name: 'Jupiter' });
-      })
-      .then(record => {
-        jupiter = record;
+    return Ember.RSVP.Promise.all([
+      store.addRecord({ type: 'planet', name: 'Earth' }),
+      store.addRecord({ type: 'planet', name: 'Jupiter' })
+    ])
+      .then(([result1, result2]) => {
+        earth = result1;
+        jupiter = result2;
         return store.query(qb.records('planet'));
       })
       .then(records => {

--- a/tests/integration/store-test.js
+++ b/tests/integration/store-test.js
@@ -90,6 +90,46 @@ module('Integration - Store', function(hooks) {
       });
   });
 
+  test('#query - relatedRecord', function(assert) {
+    let sun, jupiter;
+
+    return store.addRecord({type: 'star', name: 'The Sun'})
+      .then(result => {
+        sun = result;
+        return store.addRecord({ type: 'planet', name: 'Jupiter', sun });
+      })
+      .then(result => {
+        jupiter = result;
+        return store.query(qb.relatedRecord(jupiter.identity, 'sun'));
+      })
+      .then(record => {
+        assert.strictEqual(record, sun);
+      });
+  });
+
+  test('#query - relatedRecords', function(assert) {
+    let io, callisto, jupiter;
+
+    return Ember.RSVP.Promise.all([
+      store.addRecord({type: 'moon', name: 'Io'}),
+      store.addRecord({type: 'moon', name: 'Callisto'})
+    ])
+      .then(([result1, result2]) => {
+        io = result1;
+        callisto = result2;
+        return store.addRecord({ type: 'planet', name: 'Jupiter', moons: [io, callisto] });
+      })
+      .then(result => {
+        jupiter = result;
+        return store.query(qb.relatedRecords(jupiter.identity, 'moons'));
+      })
+      .then(records => {
+        assert.deepEqual(records, [io, callisto]);
+        assert.strictEqual(records[0], io);
+        assert.strictEqual(records[1], callisto);
+      });
+  });
+
   test('#query - filter', function(assert) {
     let earth;
 


### PR DESCRIPTION
Ensure that records are looked up from the identity map, just as they are for `record` and `records` queries.

[Fixes #127]