### PR TITLE
Evict records from identity maps as soon as they’re removed.

### DIFF
--- a/addon/cache.js
+++ b/addon/cache.js
@@ -17,7 +17,7 @@ export default Ember.Object.extend({
     Ember.assert(get(this, '_identityMap'), '_identityMap is required');
   },
 
-  containsRecord(type, id) {
+  includesRecord(type, id) {
     return this._orbitCache.has([type, id]);
   },
 

--- a/addon/identity-map.js
+++ b/addon/identity-map.js
@@ -30,7 +30,7 @@ export default Ember.Object.extend({
     return identities.map(identity => this.lookup(identity));
   },
 
-  contains(identity) {
+  includes(identity) {
     return !!this.materialized(identity);
   },
 

--- a/addon/identity-map.js
+++ b/addon/identity-map.js
@@ -1,3 +1,5 @@
+import { toIdentifier } from 'orbit/lib/identifiers';
+
 export default Ember.Object.extend({
   _schema: null,
   _orbitCache: null,
@@ -13,52 +15,54 @@ export default Ember.Object.extend({
     this._materialized = {};
   },
 
-  lookup(identifier) {
-    if (!identifier) {
+  lookup(identity) {
+    if (!identity) {
       return;
     }
 
-    const { type, id } = identifier;
-    const identifierKey = this._identifierKey(type, id);
+    const { type, id } = identity;
+    const identifier = toIdentifier(type, id);
 
-    return this._materialized[identifierKey] || this._materialize(type, id);
+    return this._materialized[identifier] || this._materialize(type, id);
   },
 
-  lookupMany(identifiers) {
-    return identifiers.map(identifier => this.lookup(identifier));
+  lookupMany(identities) {
+    return identities.map(identity => this.lookup(identity));
   },
 
-  contains(identifier) {
-    if (!identifier) {
+  contains(identity) {
+    return !!this.materialized(identity);
+  },
+
+  materialized(identity) {
+    if (!identity) {
       return;
     }
 
-    const { type, id } = identifier;
-    const identifierKey = this._identifierKey(type, id);
+    const { type, id } = identity;
+    const identifier = toIdentifier(type, id);
 
-    return !!this._materialized[identifierKey];
+    return this._materialized[identifier];
   },
 
-  evict(record) {
-    // console.debug('evicting', record);
-    const identifierKey = this._identifierKey(record.type, record.id);
-    delete this._materialized[identifierKey];
-    // console.debug('materialized after evict', identifierKey, this._materialized);
-    record.disconnect();
+  evict(identity) {
+    const record = this.materialized(identity);
+
+    if (record) {
+      const identifier = toIdentifier(identity);
+      delete this._materialized[identifier];
+      record.disconnect();
+    }
   },
 
   _materialize(type, id) {
     // console.debug('materializing', type, id);
     const model = this._schema.modelFor(type);
     const record = model._create(id, this._store);
-    const identifier = this._identifierKey(type, id);
+    const identifier = toIdentifier(type, id);
 
     this._materialized[identifier] = record;
 
     return record;
-  },
-
-  _identifierKey(type, id) {
-    return `${type}:${id}`;
   }
 });

--- a/addon/model.js
+++ b/addon/model.js
@@ -1,6 +1,7 @@
 import HasMany from './relationships/has-many';
 import { uuid } from 'orbit/lib/uuid';
 import {
+  removeRecord,
   replaceKey,
   replaceAttribute,
   replaceHasOne
@@ -69,7 +70,7 @@ const Model = Ember.Object.extend(Ember.Evented, {
 
   remove() {
     const store = get(this, '_storeOrError');
-    return store.removeRecord(this);
+    return store.update(removeRecord(this.identity));
   },
 
   disconnect() {
@@ -77,7 +78,8 @@ const Model = Ember.Object.extend(Ember.Evented, {
   },
 
   willDestroy() {
-    // console.debug('willDestroy hook');
+    // console.debug('Model#willDestroy', this.identity);
+
     if (this.trigger) {
       this.trigger('didUnload');
     }

--- a/addon/store.js
+++ b/addon/store.js
@@ -115,7 +115,9 @@ const Store = Ember.Object.extend({
   },
 
   removeRecord(record) {
-    return this.update(removeRecord(record));
+    const { type, id } = record;
+    const identity = { type, id };
+    return this.update(removeRecord(identity));
   },
 
   _verifyType(type) {
@@ -124,13 +126,22 @@ const Store = Ember.Object.extend({
 
   _didPatch: function(operation) {
     // console.debug('didPatch', operation);
+
+    let record;
     const { type, id } = operation.record;
-    const record = this._identityMap.lookup({ type, id });
 
     switch(operation.op) {
-      case 'replaceAttribute': return record.propertyDidChange(operation.attribute);
-      case 'replaceHasOne': return record.propertyDidChange(operation.relationship);
-      case 'removeRecord': return record.disconnect();
+      case 'replaceAttribute':
+        record = this._identityMap.lookup({ type, id });
+        record.propertyDidChange(operation.attribute);
+        break;
+      case 'replaceHasOne':
+        record = this._identityMap.lookup({ type, id });
+        record.propertyDidChange(operation.relationship);
+        break;
+      case 'removeRecord':
+        this._identityMap.evict({ type, id });
+        break;
     }
   }
 });

--- a/tests/integration/cache-test.js
+++ b/tests/integration/cache-test.js
@@ -57,7 +57,7 @@ module('Integration - Cache', function(hooks) {
       store
         .addRecord({type: 'planet', name: 'Jupiter'})
         .tap(jupiter => store.removeRecord(jupiter))
-        .then(jupiter => assert.ok(!planets.contains(jupiter)))
+        .then(jupiter => assert.ok(!planets.includes(jupiter)))
         .then(() => done());
     });
   });

--- a/tests/integration/cache-test.js
+++ b/tests/integration/cache-test.js
@@ -45,7 +45,7 @@ module('Integration - Cache', function(hooks) {
   test('liveQuery - updates when matching record is added', function(assert) {
     const planets = cache.liveQuery(oqe('records', 'planet'));
     const addJupiter = store.addRecord({ id: 'jupiter', type: 'planet', name: 'Jupiter' });
-    return addJupiter.then(jupiter => assert.ok(planets.contains(jupiter)));
+    return addJupiter.then(jupiter => assert.ok(planets.includes(jupiter)));
   });
 
   test('liveQuery - updates when matching record is removed', function(assert) {
@@ -70,7 +70,7 @@ module('Integration - Cache', function(hooks) {
 
       store
         .addRecord({type: 'moon', name: 'Callisto'})
-        .then(callisto => assert.ok(!planets.contains(callisto)))
+        .then(callisto => assert.ok(!planets.includes(callisto)))
         .then(() => done());
     });
   });
@@ -107,10 +107,10 @@ module('Integration - Cache', function(hooks) {
       store
         .addRecord({type: 'planet', name: 'Jupiter'})
         .tap(() => assert.equal(planets.get('length'), 1))
-        .tap(jupiter => assert.ok(planets.contains(jupiter)))
+        .tap(jupiter => assert.ok(planets.includes(jupiter)))
         .tap(jupiter => store.update(replaceAttribute(jupiter, 'name', 'Jupiter2')))
         .tap(() => assert.equal(planets.get('length'), 0))
-        .tap(jupiter => assert.ok(!planets.contains(jupiter)))
+        .tap(jupiter => assert.ok(!planets.includes(jupiter)))
         .then(() => done());
     });
   });

--- a/tests/integration/model-test.js
+++ b/tests/integration/model-test.js
@@ -54,7 +54,7 @@ module('Integration - Model', function(hooks) {
     ])
       .tap(([jupiter, callisto]) => jupiter.get('moons').pushObject(callisto))
       .then(([jupiter, callisto]) => {
-        assert.ok(jupiter.get('moons').contains(callisto), 'added record to hasMany');
+        assert.ok(jupiter.get('moons').includes(callisto), 'added record to hasMany');
         assert.equal(callisto.get('planet'), jupiter, 'updated inverse');
       });
   });
@@ -67,7 +67,7 @@ module('Integration - Model', function(hooks) {
       .tap(([jupiter, callisto]) => jupiter.get('moons').pushObject(callisto))
       .tap(([jupiter, callisto]) => jupiter.get('moons').removeObject(callisto))
       .then(([jupiter, callisto]) => {
-        assert.ok(!jupiter.get('moons').contains(callisto), 'removed record from hasMany');
+        assert.ok(!jupiter.get('moons').includes(callisto), 'removed record from hasMany');
         assert.ok(!callisto.get('planet'), 'updated inverse');
       });
   });
@@ -83,7 +83,7 @@ module('Integration - Model', function(hooks) {
       })
       .then(([jupiter, callisto]) => {
         assert.equal(callisto.get('planet'), jupiter, 'replaced hasOne with record');
-        assert.ok(jupiter.get('moons').contains(callisto), 'updated inverse');
+        assert.ok(jupiter.get('moons').includes(callisto), 'updated inverse');
       });
   });
 
@@ -102,7 +102,7 @@ module('Integration - Model', function(hooks) {
       })
       .then(([jupiter, callisto]) => {
         assert.equal(callisto.get('planet'), null, 'replaced hasOne with null');
-        assert.ok(!jupiter.get('moons').contains(callisto), 'removed from inverse hasMany');
+        assert.ok(!jupiter.get('moons').includes(callisto), 'removed from inverse hasMany');
       });
   });
 
@@ -125,7 +125,7 @@ module('Integration - Model', function(hooks) {
       .tap(record => record.destroy())
       .then(record => {
         const identifier = record.getProperties('type', 'id');
-        assert.ok(!cache.get('_identityMap').contains(identifier), 'removed from identity map');
+        assert.ok(!cache.get('_identityMap').includes(identifier), 'removed from identity map');
       });
   });
 });

--- a/tests/integration/store-test.js
+++ b/tests/integration/store-test.js
@@ -203,8 +203,8 @@ module('Integration - Store', function(hooks) {
     return forkedStore
       .addRecord({type: 'planet', name: 'Jupiter', classification: 'gas giant'})
       .then(jupiter => {
-        assert.equal(store.cache.containsRecord('planet', jupiter.get('id')), false, 'store does not contain record');
-        assert.equal(forkedStore.cache.containsRecord('planet', jupiter.get('id')), true, 'fork contains record');
+        assert.equal(store.cache.includesRecord('planet', jupiter.get('id')), false, 'store does not contain record');
+        assert.equal(forkedStore.cache.includesRecord('planet', jupiter.get('id')), true, 'fork includes record');
       });
   });
 
@@ -215,8 +215,8 @@ module('Integration - Store', function(hooks) {
       .addRecord({type: 'planet', name: 'Jupiter', classification: 'gas giant'})
       .tap(() => store.merge(forkedStore))
       .then(jupiter => {
-        assert.equal(store.cache.containsRecord('planet', jupiter.get('id')), true, 'store contains record');
-        assert.equal(forkedStore.cache.containsRecord('planet', jupiter.get('id')), true, 'fork contains record');
+        assert.equal(store.cache.includesRecord('planet', jupiter.get('id')), true, 'store includes record');
+        assert.equal(forkedStore.cache.includesRecord('planet', jupiter.get('id')), true, 'fork includes record');
       });
   });
 });

--- a/tests/integration/store-test.js
+++ b/tests/integration/store-test.js
@@ -40,7 +40,7 @@ module('Integration - Store', function(hooks) {
   });
 
   test('#findRecord - missing record', function(assert) {
-    return store.find('planet', 'jupiter')
+    return store.findRecord('planet', 'jupiter')
       .catch(e => {
         assert.equal(e.message, 'Record not found - planet:jupiter', 'query - error caught');
       });
@@ -159,18 +159,6 @@ module('Integration - Store', function(hooks) {
       });
   });
 
-  test('#find - by type and id', function(assert) {
-    let earth;
-
-    return store.addRecord({ type: 'planet', name: 'Earth' })
-      .then(record => {
-        earth = record;
-        return store.addRecord({ type: 'planet', name: 'Jupiter' });
-      })
-      .then(() => store.find('planet', earth.id))
-      .then(record => assert.strictEqual(record, earth));
-  });
-
   test('#find - by type', function(assert) {
     let earth, jupiter;
 
@@ -187,6 +175,25 @@ module('Integration - Store', function(hooks) {
         assert.deepEqual(records, [earth, jupiter]);
         assert.strictEqual(records[0], earth);
         assert.strictEqual(records[1], jupiter);
+      });
+  });
+
+  test('#find - by type and id', function(assert) {
+    let earth;
+
+    return store.addRecord({ type: 'planet', name: 'Earth' })
+      .then(record => {
+        earth = record;
+        return store.addRecord({ type: 'planet', name: 'Jupiter' });
+      })
+      .then(() => store.find('planet', earth.id))
+      .then(record => assert.strictEqual(record, earth));
+  });
+
+  test('#find - missing record', function(assert) {
+    return store.find('planet', 'jupiter')
+      .catch(e => {
+        assert.equal(e.message, 'Record not found - planet:jupiter', 'query - error caught');
       });
   });
 


### PR DESCRIPTION
Includes the following cleanup:

* use `toIdentifier` from Orbit lib instead of custom fn.
* use `includes` instead of deprecated `contains`.