### PR TITLE
Introduce wrapper classes for Source, Bucket, KeyMap, and Coordinator.

### DIFF
--- a/addon/-private/get-registered-models.js
+++ b/addon/-private/get-registered-models.js
@@ -1,0 +1,32 @@
+import Ember from 'ember';
+
+/**
+ * Retrieves models registered in the namespace of an Application or Engine.
+ *
+ * This resolution process is inefficient and should be revisited when the
+ * Ember CLI Resolver v2 is introduced, since that should allow for more
+ * targeted lookups by type via a pre-built map.
+ *
+ * @function getRegisteredModels
+ * @param  {Application} app Application or Engine which contains model modules.
+ * @return {Array}           Array of camelized model names.
+ */
+export default function(app) {
+  var prefix = app.modulePrefix;
+  var regex = new RegExp('^' + prefix + '\/models\/?\/');
+  var getKeys = (Object.keys || Ember.keys);
+  var moduleNames = getKeys(self.requirejs._eak_seen);
+  var models = [];
+
+  for (var i = 0; i < moduleNames.length; i++) {
+    var moduleName = moduleNames[i];
+    var matches = regex.exec(moduleName);
+    if (matches && matches.length === 1) {
+      var model = moduleName.match(/[^\/]+\/?$/)[0];
+      model = Ember.String.camelize(model);
+      models.push(model);
+    }
+  }
+
+  return models;
+}

--- a/addon/bucket.js
+++ b/addon/bucket.js
@@ -1,0 +1,23 @@
+const { assert } = Ember;
+
+export default Ember.Object.extend({
+  OrbitBucketClass: null,
+  orbitBucket: null,
+  orbitBucketOptions: null,
+
+  init() {
+    this._super(...arguments);
+
+    if (!this.orbitBucket) {
+      let OrbitBucketClass = this.OrbitBucketClass;
+      if (OrbitBucketClass.wrappedFunction) {
+        OrbitBucketClass = OrbitBucketClass.wrappedFunction;
+      }
+
+      assert('OrbitBucketClass or orbitBucket must be specified to construct a Bucket.', OrbitBucketClass);
+
+      let options = this.orbitBucketOptions || {};
+      this.orbitBucket = new OrbitBucketClass(options);
+    }
+  }
+});

--- a/addon/coordinator.js
+++ b/addon/coordinator.js
@@ -1,0 +1,21 @@
+import OrbitCoordinator from 'orbit/coordinator';
+
+export default Ember.Object.extend({
+  orbitCoordinator: null,
+
+  init() {
+    this._super(...arguments);
+
+    if (!this.orbitCoordinator) {
+      this.orbitCoordinator = new OrbitCoordinator();
+    }
+  },
+
+  addSource(source) {
+    this.orbitCoordinator.addSource(source.orbitSource);
+  },
+
+  removeSource(source) {
+    this.orbitCoordinator.removeSource(source.orbitSource);
+  }
+});

--- a/addon/initializers/ember-orbit.js
+++ b/addon/initializers/ember-orbit.js
@@ -2,13 +2,18 @@ import Ember from 'ember';
 import Orbit from 'orbit';
 import Store from 'ember-orbit/store';
 import Schema from 'ember-orbit/schema';
+import KeyMap from 'ember-orbit/key-map';
 
 export function initialize(application) {
   Orbit.Promise = Ember.RSVP.Promise;
 
-  application.register('schema:main', Schema);
+  application.register('data-key-map:main', KeyMap);
+  application.register('data-schema:main', Schema);
   application.register('service:store', Store);
-  application.inject('service:store', 'schema', 'schema:main');
+  application.inject('service:store', 'schema', 'data-schema:main');
+  application.inject('data-source', 'schema', 'data-schema:main');
+  application.inject('service:store', 'keyMap', 'data-key-map:main');
+  application.inject('data-source', 'keyMap', 'data-key-map:main');
   application.inject('route', 'store', 'service:store');
   application.inject('controller', 'store', 'service:store');
 }

--- a/addon/initializers/ember-orbit.js
+++ b/addon/initializers/ember-orbit.js
@@ -3,17 +3,21 @@ import Orbit from 'orbit';
 import Store from 'ember-orbit/store';
 import Schema from 'ember-orbit/schema';
 import KeyMap from 'ember-orbit/key-map';
+import Coordinator from 'ember-orbit/coordinator';
 
 export function initialize(application) {
   Orbit.Promise = Ember.RSVP.Promise;
 
   application.register('data-key-map:main', KeyMap);
   application.register('data-schema:main', Schema);
+  application.register('data-coordinator:main', Coordinator);
   application.register('service:store', Store);
   application.inject('service:store', 'schema', 'data-schema:main');
-  application.inject('data-source', 'schema', 'data-schema:main');
   application.inject('service:store', 'keyMap', 'data-key-map:main');
+  application.inject('service:store', 'coordinator', 'data-coordinator:main');
+  application.inject('data-source', 'schema', 'data-schema:main');
   application.inject('data-source', 'keyMap', 'data-key-map:main');
+  application.inject('data-source', 'coordinator', 'data-coordinator:main');
   application.inject('route', 'store', 'service:store');
   application.inject('controller', 'store', 'service:store');
 }

--- a/addon/key-map.js
+++ b/addon/key-map.js
@@ -1,0 +1,13 @@
+import OrbitKeyMap from 'orbit/key-map';
+
+export default Ember.Object.extend({
+  orbitKeyMap: null,
+
+  init() {
+    this._super(...arguments);
+
+    if (!this.orbitKeyMap) {
+      this.orbitKeyMap = new OrbitKeyMap();
+    }
+  }
+});

--- a/addon/source.js
+++ b/addon/source.js
@@ -1,0 +1,66 @@
+import OrbitSource from 'orbit/source';
+
+const { assert } = Ember;
+
+export default Ember.Object.extend({
+  OrbitSourceClass: OrbitSource,
+  orbitSource: null,
+  orbitSourceOptions: null,
+  keyMap: null,
+  schema: null,
+
+  init() {
+    this._super(...arguments);
+
+    assert("`schema` must be injected onto a Source", this.schema);
+    assert("`keyMap` must be injected onto a Source", this.keyMap);
+
+    if (!this.orbitSource) {
+      let OrbitSourceClass = this.OrbitSourceClass;
+      if (OrbitSourceClass.wrappedFunction) {
+        OrbitSourceClass = OrbitSourceClass.wrappedFunction;
+      }
+
+      let options = this.orbitSourceOptions || {};
+      options.schema = this.schema.orbitSchema;
+      options.keyMap = this.keyMap.orbitKeyMap;
+      this.orbitSource = new OrbitSourceClass(options);
+    }
+
+    this.transformLog = this.orbitSource.transformLog;
+    this.requestQueue = this.orbitSource.requestQueue;
+    this.syncQueue = this.orbitSource.syncQueue;
+  },
+
+  on() {
+    return this.orbitSource.on(...arguments);
+  },
+
+  off() {
+    return this.orbitSource.off(...arguments);
+  },
+
+  one() {
+    return this.orbitSource.one(...arguments);
+  },
+
+  pull() {
+    return this.orbitSource.pull(...arguments);
+  },
+
+  push() {
+    return this.orbitSource.push(...arguments);
+  },
+
+  query() {
+    return this.orbitSource.query(...arguments);
+  },
+
+  sync() {
+    return this.orbitSource.sync(...arguments);
+  },
+
+  update() {
+    return this.orbitSource.update(...arguments);
+  }
+});

--- a/addon/source.js
+++ b/addon/source.js
@@ -8,6 +8,8 @@ export default Ember.Object.extend({
   orbitSourceOptions: null,
   keyMap: null,
   schema: null,
+  bucket: null,
+  coordinator: null,
 
   init() {
     this._super(...arguments);
@@ -24,12 +26,26 @@ export default Ember.Object.extend({
       let options = this.orbitSourceOptions || {};
       options.schema = this.schema.orbitSchema;
       options.keyMap = this.keyMap.orbitKeyMap;
+      if (this.bucket) {
+        options.bucket = this.bucket.orbitBucket;
+      }
+
       this.orbitSource = new OrbitSourceClass(options);
     }
 
     this.transformLog = this.orbitSource.transformLog;
     this.requestQueue = this.orbitSource.requestQueue;
     this.syncQueue = this.orbitSource.syncQueue;
+
+    if (this.coordinator) {
+      this.coordinator.addSource(this);
+    }
+  },
+
+  willDestroy() {
+    if (this.coordinator) {
+      this.coordinator.removeSource(this);
+    }
   },
 
   on() {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "ember-cli-babel": "^5.1.6",
     "immutable": "^3.8.1",
     "orbit-core": "^0.8.0-beta.6",
-    "orbit-store": "^0.8.0-beta.3",
+    "orbit-store": "^0.8.0-beta.4",
     "resolve": "^1.1.7",
     "rxjs-es": "^5.0.0-beta.11"
   },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "broccoli-replace": "^0.12.0",
     "ember-cli-babel": "^5.1.6",
     "immutable": "^3.8.1",
-    "orbit-core": "^0.8.0-beta.4",
+    "orbit-core": "^0.8.0-beta.6",
     "orbit-store": "^0.8.0-beta.3",
     "resolve": "^1.1.7",
     "rxjs-es": "^5.0.0-beta.11"

--- a/tests/integration/schema-test.js
+++ b/tests/integration/schema-test.js
@@ -20,76 +20,58 @@ module("Integration - Schema", function(hooks) {
     schema = null;
   });
 
-  test("it exists", function() {
-    ok(schema);
+  test("it exists", function(assert) {
+    assert.ok(schema);
   });
 
-  test("#defineModel defines models on the underlying Orbit schema", function() {
+  test("#types - specifies models that are defined on the underlying Orbit schema", function(assert) {
     schema.modelFor('planet');
 
-    deepEqual(schema.models(), ['planet', 'star', 'moon']);
+    assert.deepEqual(schema.get('types'), ['planet', 'moon', 'star']);
 
-    deepEqual(schema.attributes('star'), ['name', 'isStable']);
-    deepEqual(schema.relationships('star'), ['planets']);
-    deepEqual(schema.attributeProperties('star', 'name'), {
+    assert.deepEqual(schema.attributes('star'), ['name', 'isStable']);
+    assert.deepEqual(schema.relationships('star'), ['planets']);
+    assert.deepEqual(schema.attributeProperties('star', 'name'), {
       type: "string"
     });
-    deepEqual(schema.relationshipProperties('star', 'planets'), {
+    assert.deepEqual(schema.relationshipProperties('star', 'planets'), {
       type:  "hasMany",
       model: "planet"
     });
 
-    deepEqual(schema.attributes('moon'), ['name']);
-    deepEqual(schema.relationships('moon'), ['planet']);
-    deepEqual(schema.attributeProperties('moon', 'name'), {
+    assert.deepEqual(schema.attributes('moon'), ['name']);
+    assert.deepEqual(schema.relationships('moon'), ['planet']);
+    assert.deepEqual(schema.attributeProperties('moon', 'name'), {
       type: "string"
     });
-    deepEqual(schema.relationshipProperties('moon', 'planet'), {
+    assert.deepEqual(schema.relationshipProperties('moon', 'planet'), {
       inverse: "moons",
       type:  "hasOne",
       model: "planet"
     });
 
-    deepEqual(schema.attributes('planet'), ['name', 'atmosphere', 'classification']);
-    deepEqual(schema.relationships('planet'), ['sun', 'moons']);
-    deepEqual(schema.attributeProperties('planet', 'name'), {
+    assert.deepEqual(schema.attributes('planet'), ['name', 'atmosphere', 'classification']);
+    assert.deepEqual(schema.relationships('planet'), ['sun', 'moons']);
+    assert.deepEqual(schema.attributeProperties('planet', 'name'), {
       type: "string"
     });
-    deepEqual(schema.attributeProperties('planet', 'classification'), {
+    assert.deepEqual(schema.attributeProperties('planet', 'classification'), {
       type: "string"
     });
-    deepEqual(schema.relationshipProperties('planet', 'sun'), {
+    assert.deepEqual(schema.relationshipProperties('planet', 'sun'), {
       type:  "hasOne",
       model: "star"
     });
-    deepEqual(schema.relationshipProperties('planet', 'moons'), {
+    assert.deepEqual(schema.relationshipProperties('planet', 'moons'), {
       inverse: "planet",
       type:  "hasMany",
       model: "moon"
     });
   });
 
-  test("#modelFor returns the appropriate model when passed a model's name", function() {
-    equal(schema.modelFor('planet'), Planet);
+  test("#modelFor returns the appropriate model when passed a model's name", function(assert) {
+    assert.strictEqual(schema.modelFor('planet'), Planet);
   });
-
-  // test("#modelFor ensures that related models are also registered in the schema", function() {
-  //   const registry = new Ember.Registry();
-  //   const container = registry.container();
-
-  //   registry.register('schema:main', Schema);
-  //   registry.register('model:planet', Planet);
-  //   registry.register('model:star', Star);
-  //   registry.register('model:moon', Moon);
-
-  //   set(schema, 'container', container);
-
-  //   deepEqual(schema.models(), [], 'no models have been registered');
-
-  //   schema.modelFor('planet');
-
-  //   deepEqual(schema.models(), ['planet', 'star', 'moon'], 'all related models have been registered');
-  // });
 
   test('#normalize', function(assert) {
     const done = assert.async();

--- a/tests/integration/store-test.js
+++ b/tests/integration/store-test.js
@@ -42,7 +42,7 @@ module('Integration - Store', function(hooks) {
   test('#findRecord - missing record', function(assert) {
     return store.findRecord('planet', 'jupiter')
       .catch(e => {
-        assert.equal(e.message, 'Record not found - planet:jupiter', 'query - error caught');
+        assert.equal(e.message, 'Record not found: planet:jupiter', 'query - error caught');
       });
   });
 
@@ -193,7 +193,7 @@ module('Integration - Store', function(hooks) {
   test('#find - missing record', function(assert) {
     return store.find('planet', 'jupiter')
       .catch(e => {
-        assert.equal(e.message, 'Record not found - planet:jupiter', 'query - error caught');
+        assert.equal(e.message, 'Record not found: planet:jupiter', 'query - error caught');
       });
   });
 

--- a/tests/support/store.js
+++ b/tests/support/store.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import Store from 'ember-orbit/store';
 import Schema from 'ember-orbit/schema';
+import KeyMap from 'ember-orbit/key-map';
 import Owner from './owner';
 
 function createOwner() {
@@ -20,9 +21,11 @@ function createStore(options) {
 
   const owner = createOwner();
 
-  owner.register('schema:main', Schema);
-  owner.register('store:main', Store);
-  owner.inject('store', 'schema', 'schema:main');
+  owner.register('data-schema:main', Schema);
+  owner.register('data-key-map:main', KeyMap);
+  owner.register('service:store', Store);
+  owner.inject('service:store', 'schema', 'data-schema:main');
+  owner.inject('service:store', 'keyMap', 'data-key-map:main');
 
   const models = options.models;
   if (models) {
@@ -31,7 +34,7 @@ function createStore(options) {
     }
   }
 
-  const store = owner.lookup('store:main');
+  const store = owner.lookup('service:store');
   const schema = store.schema;
 
   if (models) {

--- a/tests/support/store.js
+++ b/tests/support/store.js
@@ -29,21 +29,16 @@ function createStore(options) {
 
   const models = options.models;
   if (models) {
-    for (let prop in models) {
-      owner.register('model:' + prop, models[prop]);
-    }
+    let types = [];
+    Object.keys(models).forEach(type => {
+      owner.register(`model:${type}`, models[type]);
+      types.push(type);
+    });
+    owner.register('data-types:main', types, { instantiate: false });
+    owner.inject('data-schema:main', 'types', 'data-types:main');
   }
 
-  const store = owner.lookup('service:store');
-  const schema = store.schema;
-
-  if (models) {
-    for (let model in models) {
-      schema.modelFor(model);
-    }
-  }
-
-  return store;
+  return owner.lookup('service:store');
 }
 
 export { createOwner, createStore };

--- a/tests/unit/bucket-test.js
+++ b/tests/unit/bucket-test.js
@@ -1,0 +1,25 @@
+import OrbitBucket from 'orbit/bucket';
+import Bucket from 'ember-orbit/bucket';
+
+module('Unit - Bucket', function() {
+  test('can be instantiated from an existing Orbit Bucket', function(assert) {
+    const orbitBucket = new OrbitBucket();
+
+    const bucket = Bucket.create({
+      orbitBucket
+    });
+
+    assert.ok(bucket, 'bucket has been created');
+  });
+
+  test('can be instantiated given an OrbitBucketClass', function(assert) {
+    const bucket = Bucket.create({
+      OrbitBucketClass: OrbitBucket,
+      orbitBucketOptions: { name: 'ze-bucket' }
+    });
+
+    assert.ok(bucket, 'bucket has been created');
+    assert.ok(bucket.orbitBucket instanceof OrbitBucket, 'bucket.orbitBucket has been instantiated from specified class');
+    assert.equal(bucket.orbitBucket.name, 'ze-bucket', 'options have been passed to Orbit Bucket');
+  });
+});

--- a/tests/unit/coordinator-test.js
+++ b/tests/unit/coordinator-test.js
@@ -1,0 +1,46 @@
+import OrbitCoordinator from 'orbit/coordinator';
+import Coordinator from 'ember-orbit/coordinator';
+import { dummyModels } from 'dummy/tests/support/dummy-models';
+import { createStore } from 'dummy/tests/support/store';
+
+const { Planet, Moon, Star } = dummyModels;
+
+module('Unit - Coordinator', function() {
+  test('can be instantiated', function(assert) {
+    assert.expect(2);
+
+    const coordinator = Coordinator.create();
+
+    assert.ok(coordinator, 'coordinator has been created');
+    assert.ok(coordinator.orbitCoordinator instanceof OrbitCoordinator, 'coordinator.orbitCoordinator has been instantiated from Orbit Coordinator');
+  });
+
+  test('can be instantiated from an existing Orbit Coordinator', function(assert) {
+    assert.expect(2);
+
+    const orbitCoordinator = new OrbitCoordinator();
+
+    const coordinator = Coordinator.create({
+      orbitCoordinator
+    });
+
+    assert.ok(coordinator, 'coordinator has been created');
+    assert.strictEqual(coordinator.orbitCoordinator, orbitCoordinator, 'coordinator.orbitCoordinator matches custom coordinator');
+  });
+
+  test('#addSource adds an EO.Source, and #removeSource removes it', function(assert) {
+    assert.expect(2);
+
+    const coordinator = Coordinator.create();
+    const models = { planet: Planet, moon: Moon, star: Star };
+    const store = createStore({ models });
+
+    coordinator.addSource(store);
+
+    assert.ok(coordinator.orbitCoordinator._sources.includes(store.orbitSource), 'source has been added to underlying Orbit coordinator');
+
+    coordinator.removeSource(store);
+
+    assert.ok(!coordinator.orbitCoordinator._sources.includes(store.orbitSource), 'source has been removed from underlying Orbit coordinator');
+  });
+});

--- a/tests/unit/key-map-test.js
+++ b/tests/unit/key-map-test.js
@@ -1,0 +1,20 @@
+import OrbitKeyMap from 'orbit/key-map';
+import KeyMap from 'ember-orbit/key-map';
+
+module('Unit - KeyMap', function() {
+  test('can be instantiated', function(assert) {
+    const keyMap = KeyMap.create();
+
+    assert.ok(keyMap, 'keyMap has been created');
+  });
+
+  test('can be instantiated from an existing Orbit KeyMap', function(assert) {
+    const orbitKeyMap = new OrbitKeyMap();
+
+    const keyMap = KeyMap.create({
+      orbitKeyMap
+    });
+
+    assert.ok(keyMap, 'keyMap has been created');
+  });
+});


### PR DESCRIPTION
By using Ember classes, we can take full advantage of Ember's DI system.

Also, removes the complexities related to lazy registration of models, which is no longer supported by orbit-core (instead favoring an explicit schema version that can be upgraded).