### PR TITLE
Introduce Store#findRecordByKey

### DIFF
--- a/addon/-private/store.js
+++ b/addon/-private/store.js
@@ -116,6 +116,16 @@ const Store = Ember.Object.extend({
     return this.query(q => q.findRecord({ type, id }), options);
   },
 
+  findRecordByKey(type, keyName, keyValue, options) {
+    let keyMap = this.source.keyMap;
+    let id = keyMap.keyToId(type, keyName, keyValue);
+    if (!id) {
+      id = this.source.schema.generateId(type);
+      keyMap.pushRecord({ type, id, keys: { [keyName]: keyValue } });
+    }
+    return this.findRecord(type, id, options);
+  },
+
   removeRecord(identity, options) {
     return this.update(t => t.removeRecord(identity), options);
   },

--- a/tests/integration/model-test.js
+++ b/tests/integration/model-test.js
@@ -21,12 +21,12 @@ module('Integration - Model', function(hooks) {
     ])
       .then(([theSun, callisto]) => {
         return store
-          .addRecord({type: 'planet', galaxyAlias: 'planet:jupiter', name: 'Jupiter', sun: theSun, moons: [callisto]})
+          .addRecord({type: 'planet', remoteId: 'planet:jupiter', name: 'Jupiter', sun: theSun, moons: [callisto]})
           .then(record => {
             assert.ok(record.get('id'), 'assigned id');
             assert.deepEqual(record.get('identity'), { id: record.get('id'), type: 'planet' }, 'assigned identity that includes type and id');
             assert.equal(record.get('name'), 'Jupiter', 'assigned specified attribute');
-            assert.equal(record.get('galaxyAlias'), 'planet:jupiter', 'assigned secondary key');
+            assert.equal(record.get('remoteId'), 'planet:jupiter', 'assigned secondary key');
             assert.strictEqual(record.get('sun'), theSun, 'assigned hasOne');
             assert.strictEqual(record.get('moons.firstObject'), callisto, 'assigned hasMany');
           });
@@ -125,9 +125,9 @@ module('Integration - Model', function(hooks) {
   });
 
   test('replace key', function(assert) {
-    return store.addRecord({type: 'planet', name: 'Jupiter', galaxyAlias: 'planet:jupiter'})
-      .tap(record => record.set('galaxyAlias', 'planet:joopiter'))
-      .then(record => assert.equal(record.get('galaxyAlias'), 'planet:joopiter'));
+    return store.addRecord({type: 'planet', name: 'Jupiter', remoteId: 'planet:jupiter'})
+      .tap(record => record.set('remoteId', 'planet:joopiter'))
+      .then(record => assert.equal(record.get('remoteId'), 'planet:joopiter'));
   });
 
   test('destroy model', function(assert) {

--- a/tests/support/dummy-models.js
+++ b/tests/support/dummy-models.js
@@ -7,7 +7,7 @@ import {
 } from 'ember-orbit';
 
 export const Planet = Model.extend({
-  galaxyAlias: key(),
+  remoteId: key(),
   name: attr('string'),
   atmosphere: attr('boolean'),
   classification: attr('string'),


### PR DESCRIPTION
Used to find records by key instead of local id.

First looks up a local id for a given key and, if none is present in the
keyMap, generates a new local id and adds it to the keyMap.

Next `findRecord` is called for the `type` and local `id`.

In this way the same id:key mapping will be accessible for other 
sources.