### PR TITLE
Add model#replaceAttributes method

### DIFF
--- a/addon/-private/model.js
+++ b/addon/-private/model.js
@@ -56,6 +56,13 @@ const Model = EmberObject.extend(Evented, {
     });
   },
 
+  replaceAttributes(properties, options) {
+    const store = get(this, '_storeOrError');
+    const keys = Object.keys(properties);
+    return store.update(t => keys.map(key => t.replaceAttribute(this.identity, key, properties[key])), options)
+      .then(() => this);
+  },
+
   remove(options) {
     const store = get(this, '_storeOrError');
     return store.update(t => t.removeRecord(this.identity), options);

--- a/tests/integration/model-test.js
+++ b/tests/integration/model-test.js
@@ -126,6 +126,15 @@ module('Integration - Model', function(hooks) {
       .then(record => assert.equal(record.get('name'), 'Jupiter2'));
   });
 
+  test('replace attributes on model', function(assert) {
+    return store.addRecord({ type: 'planet', name: 'Jupiter' })
+      .then(record => record.replaceAttributes({ name: 'Jupiter2', classification: 'gas giant2' }))
+      .then(record => {
+        assert.equal(record.get('name'), 'Jupiter2');
+        assert.equal(record.get('classification'), 'gas giant2');
+      });
+  });
+
   test('replace key', function(assert) {
     return store.addRecord({type: 'planet', name: 'Jupiter', remoteId: 'planet:jupiter'})
       .tap(record => record.set('remoteId', 'planet:joopiter'))


### PR DESCRIPTION
The motivation behind having `update` method is the fact there is no easy way today to bulk update attributes of a model and wait on the change to be propagated.