### PR TITLE
Ensure that Store#addRecord always returns a record on success

### DIFF
--- a/addon/-private/store.js
+++ b/addon/-private/store.js
@@ -98,8 +98,9 @@ const Store = EmberObject.extend({
   },
 
   addRecord(properties = {}, options) {
-    return this.update(t => t.addRecord(this.normalizeRecordProperties(properties)), options)
-      .then(record => this._identityMap.lookup(record));
+    let record = this.normalizeRecordProperties(properties);
+    return this.update(t => t.addRecord(record), options)
+      .then(() => this._identityMap.lookup(record));
   },
 
   find(type, id, options) {

--- a/tests/integration/store-test.js
+++ b/tests/integration/store-test.js
@@ -65,6 +65,19 @@ module('Integration - Store', function(hooks) {
       });
   });
 
+  test('#addRecord - with blocking sync updates', function(assert) {
+    store.source.on('beforeUpdate', (transform) => {
+      return store.source.sync(transform);
+    });
+
+    return store.addRecord({ type: 'planet', name: 'Earth' })
+      .then(function(planet) {
+         assert.ok(planet instanceof Planet);
+         assert.ok(get(planet, 'id'), 'assigned id');
+         assert.equal(get(planet, 'name'), 'Earth');
+      });
+  });
+
   test('#findRecord', function(assert) {
     return store.addRecord({ type: 'planet', name: 'Earth' })
       .then( record => store.findRecord('planet', record.id))


### PR DESCRIPTION
In blocking coordination scenarios, the store’s `beforeUpdate` event may be used to `sync` a change back to the store before `update` is called. In this scenario, `addRecord` will not return a new record.

Instead, we should prepare the record instance before calling `update`. This instance can then be used to look up the model from the identity map regardless of the return value of `update`.