### PR TITLE
Ensure that models receive injections

### DIFF
--- a/addon/-private/model.js
+++ b/addon/-private/model.js
@@ -1,4 +1,5 @@
 import EmberError from '@ember/error';
+import { assert } from '@ember/debug';
 import { empty } from '@ember/object/computed';
 import Evented from '@ember/object/evented';
 import EmberObject, { set, get, computed } from '@ember/object';
@@ -96,15 +97,10 @@ const Model = EmberObject.extend(Evented, {
   })
 });
 
-const _create = Model.create;
-
 Model.reopenClass({
-  _create(id, store) {
-    return _create.call(this, { id, type: this.typeKey, _store: store });
-  },
-
-  create() {
-    throw new EmberError("You should not call `create` on a model. Instead, call `store.addRecord` with the attributes you would like to set.");
+  create(injections) {
+    assert("You should not call `create` on a model. Instead, call `store.addRecord` with the attributes you would like to set.", injections._store);
+    return this._super(...arguments);
   },
 
   keys: computed(function() {

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -1,5 +1,5 @@
 import { get } from '@ember/object';
-import { 
+import {
   key,
   attr,
   hasOne,


### PR DESCRIPTION
Models should be created through Ember’s DI system to ensure that they receive injections, including the “owner” and services.

Fixes #160