### PR TITLE
 Fix nullable hasOne relationships

### DIFF
--- a/addon/-private/live-query.js
+++ b/addon/-private/live-query.js
@@ -35,6 +35,7 @@ export default ReadOnlyArrayProxy.extend({
         } else if (typeof results === 'object') {
           content = Object.keys(results).map(r => this._identityMap.lookup(results[r]))
         }
+        // eslint-disable-next-line ember/no-side-effects
         set(this, '_content', content);
       }
       return this._content;

--- a/addon/-private/store.js
+++ b/addon/-private/store.js
@@ -250,7 +250,8 @@ const Store = EmberObject.extend({
         }
         return { type, id };
       });
-
+    } else if (value === null) {
+      relationship.data = null;
     } else if (typeof value === 'object') {
       let id = get(value, 'id');
       relationship.data = { type, id };

--- a/tests/integration/store-test.js
+++ b/tests/integration/store-test.js
@@ -56,6 +56,17 @@ module('Integration - Store', function(hooks) {
     assert.strictEqual(normalized.relationships, undefined, 'normalized hasMany');
   });
 
+  test('#normalizeRecordProperties - nullable relationships', function(assert) {
+    const normalized = store.normalizeRecordProperties({
+      type: 'planet',
+      id: 'jupiter',
+      name: 'Jupiter',
+      sun: null
+    });
+
+    assert.deepEqual(normalized.relationships.sun, { data: null }, 'normalized nullable hasOne');
+  });
+
   test('#addRecord', function(assert) {
     return store.addRecord({ type: 'planet', name: 'Earth' })
       .then(function(planet) {


### PR DESCRIPTION
Fixes a `Cannot call get with 'id' on an undefined object` assertion thrown from `Ember.get` when a hasOne relationship has a `null` value.

---

In the second commit, I had to silence (as a temporary solution for now) this ESLint error in `live-query.js`: 
```
Don't introduce side-effects in computed properties  ember/no-side-effects
```

It did not occur when installing the dependencies with the lock file, but it was failing in Travis which uses the `--no-lockfile` flag, so apparently an update of the Ember ESLint plugin brought in this stricter check!?