### PR TITLE
Store#removeRecord - works with records or identities

### DIFF
--- a/addon/-private/store.js
+++ b/addon/-private/store.js
@@ -130,7 +130,8 @@ const Store = EmberObject.extend({
   },
 
   removeRecord(identity, options) {
-    return this.update(t => t.removeRecord(identity), options);
+    const { type, id } = identity;
+    return this.update(t => t.removeRecord({ type, id }), options);
   },
 
   on() {

--- a/tests/integration/store-test.js
+++ b/tests/integration/store-test.js
@@ -128,13 +128,58 @@ module('Integration - Store', function(hooks) {
       });
   });
 
-  test('#removeRecord', function(assert) {
-    return store.addRecord({ type: 'planet', name: 'Earth' })
-      .tap(record => store.removeRecord(record))
-      .then(record => store.findRecord('planet', record.id))
-      .catch(error => {
-        assert.ok(error.message.match(/Record not found/));
-      });
+  test('#removeRecord - when passed a record, it should serialize its identity in a `removeRecord` op', async function(assert) {
+    assert.expect(2);
+
+    let record = await store.addRecord({ type: 'planet', name: 'Earth' });
+
+    store.on('update', (data) => {
+      assert.deepEqual(
+        data.operations,
+        [
+          {
+            op: 'removeRecord',
+            record: { type: 'planet', id: record.id }
+          }
+        ],
+        'only the identity has been serialized in the operation'
+      );
+    });
+
+    await store.removeRecord(record);
+
+    try {
+      await store.findRecord('planet', record.id);
+    } catch(error) {
+      assert.ok(error.message.match(/Record not found/));
+    }
+  });
+
+  test('#removeRecord - when passed an identity', async function(assert) {
+    assert.expect(2);
+
+    let record = await store.addRecord({ type: 'planet', name: 'Earth' });
+
+    store.on('update', (data) => {
+      assert.deepEqual(
+        data.operations,
+        [
+          {
+            op: 'removeRecord',
+            record: { type: 'planet', id: record.id }
+          }
+        ],
+        'only the identity has been serialized in the operation'
+      );
+    });
+
+    await store.removeRecord({ type: 'planet', id: record.id });
+
+    try {
+      await store.findRecord('planet', record.id);
+    } catch(error) {
+      assert.ok(error.message.match(/Record not found/));
+    }
   });
 
   test('#getTransform - returns a particular transform given an id', function(assert) {


### PR DESCRIPTION
Ensure that record identities are serialized in the associated `removeRecord` operation, rather than serializing the class (which won’t be persisted successfully to a bucket, for instance).