### PR TITLE
Ensure that replaceKey operations are reflected in loaded models

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,23 +27,22 @@ jobs:
 
   include:
     # runs linting and tests with current locked deps
+    - stage: tests
+      name: "Linting"
+      script: yarn lint:js
+    - name: "Basic tests"
+      script: yarn test
 
-    - stage: "Tests"
-      name: "Tests"
-      script:
-        - npm run lint:hbs
-        - npm run lint:js
-        - npm test
-
-    # we recommend new addons test the current and previous LTS
-    # as well as latest stable release (bonus points to beta/canary)
-    - stage: "Additional Tests"
-      env: EMBER_TRY_SCENARIO=ember-lts-2.16
-    - env: EMBER_TRY_SCENARIO=ember-lts-2.18
-    - env: EMBER_TRY_SCENARIO=ember-release
-    - env: EMBER_TRY_SCENARIO=ember-beta
-    - env: EMBER_TRY_SCENARIO=ember-canary
-    - env: EMBER_TRY_SCENARIO=ember-default-with-jquery
+    # runs tests against each supported Ember version
+    - stage: ember version tests
+      name: "Ember LTS 3.4"
+      env: EMBER_TRY_SCENARIO=ember-lts-3.4
+    - name: "Ember Release"
+      env: EMBER_TRY_SCENARIO=ember-release
+    - name: "Ember Beta"
+      env: EMBER_TRY_SCENARIO=ember-beta
+    - name: "Ember Canary"
+      env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash

--- a/addon/-private/store.js
+++ b/addon/-private/store.js
@@ -162,7 +162,7 @@ const Store = EmberObject.extend({
     return this.source.getInverseOperations(...arguments);
   },
 
-  _didPatch: function(operation) {
+  _didPatch(operation) {
     // console.debug('didPatch', operation);
 
     const replacement = operation.record;
@@ -185,6 +185,10 @@ const Store = EmberObject.extend({
       case 'replaceAttribute':
         record = this._identityMap.lookup({ type, id });
         record.notifyPropertyChange(operation.attribute);
+        break;
+      case 'replaceKey':
+        record = this._identityMap.lookup({ type, id });
+        record.notifyPropertyChange(operation.key);
         break;
       case 'replaceRelatedRecord':
         record = this._identityMap.lookup({ type, id });

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -12,26 +12,10 @@ module.exports = function() {
       useYarn: true,
       scenarios: [
         {
-          name: 'ember-lts-2.16',
-          env: {
-            EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true }),
-          },
+          name: 'ember-lts-3.4',
           npm: {
             devDependencies: {
-              '@ember/jquery': '^0.5.1',
-              'ember-source': '~2.16.0'
-            }
-          }
-        },
-        {
-          name: 'ember-lts-2.18',
-          env: {
-            EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true }),
-          },
-          npm: {
-            devDependencies: {
-              '@ember/jquery': '^0.5.1',
-              'ember-source': '~2.18.0'
+              'ember-source': '~3.4.0'
             }
           }
         },
@@ -63,19 +47,6 @@ module.exports = function() {
           name: 'ember-default',
           npm: {
             devDependencies: {}
-          }
-        },
-        {
-          name: 'ember-default-with-jquery',
-          env: {
-            EMBER_OPTIONAL_FEATURES: JSON.stringify({
-              'jquery-integration': true
-            })
-          },
-          npm: {
-            devDependencies: {
-              '@ember/jquery': '^0.5.1'
-            }
           }
         }
       ]

--- a/tests/integration/model-test.js
+++ b/tests/integration/model-test.js
@@ -1,10 +1,10 @@
 import EmberError from '@ember/error';
 import EmberObject from '@ember/object';
-import { Promise as EmberPromise } from 'rsvp';
 import { Planet, Moon, Star } from 'dummy/tests/support/dummy-models';
 import { createStore } from 'dummy/tests/support/store';
 import { module, test } from 'qunit';
 import { getOwner } from '@ember/application';
+import { waitForSource } from 'ember-orbit/test-support';
 
 module('Integration - Model', function(hooks) {
   let store;
@@ -38,139 +38,114 @@ module('Integration - Model', function(hooks) {
     assert.equal(model.foo.bar, 'bar', 'service is correct');
   });
 
-  test('add new model', function(assert) {
-    return EmberPromise.all([
-      store.addRecord({type: 'star', name: 'The Sun'}),
-      store.addRecord({type: 'moon', name: 'Callisto'})
-    ])
-      .then(([theSun, callisto]) => {
-        return store
-          .addRecord({type: 'planet', remoteId: 'planet:jupiter', name: 'Jupiter', sun: theSun, moons: [callisto]})
-          .then(record => {
-            assert.ok(record.get('id'), 'assigned id');
-            assert.deepEqual(record.get('identity'), { id: record.get('id'), type: 'planet' }, 'assigned identity that includes type and id');
-            assert.equal(record.get('name'), 'Jupiter', 'assigned specified attribute');
-            assert.equal(record.get('remoteId'), 'planet:jupiter', 'assigned secondary key');
-            assert.strictEqual(record.get('sun'), theSun, 'assigned hasOne');
-            assert.strictEqual(record.get('moons.firstObject'), callisto, 'assigned hasMany');
-          });
-      });
+  test('add new model', async function(assert) {
+    const theSun = await store.addRecord({type: 'star', name: 'The Sun'});
+    const callisto = await store.addRecord({type: 'moon', name: 'Callisto'});
+    const record = await store.addRecord({type: 'planet', remoteId: 'planet:jupiter', name: 'Jupiter', sun: theSun, moons: [callisto]});
+
+    assert.ok(record.get('id'), 'assigned id');
+    assert.deepEqual(record.get('identity'), { id: record.get('id'), type: 'planet' }, 'assigned identity that includes type and id');
+    assert.equal(record.get('name'), 'Jupiter', 'assigned specified attribute');
+    assert.equal(record.get('remoteId'), 'planet:jupiter', 'assigned secondary key');
+    assert.strictEqual(record.get('sun'), theSun, 'assigned hasOne');
+    assert.strictEqual(record.get('moons.firstObject'), callisto, 'assigned hasMany');
   });
 
-  test('remove model', function(assert) {
+  test('remove model', async function(assert) {
     const cache = store.get('cache');
 
-    return store.addRecord({type: 'star', name: 'The Sun'})
-      .tap(record => record.remove())
-      .then(record => {
-        assert.ok(!cache.retrieveRecord('star', record.id), 'record does not exist in cache');
-        assert.ok(record.get('disconnected'), 'record has been disconnected from store');
-        assert.throws(() => record.get('name'), EmberError, 'record has been removed from Store');
-      });
+    const record = await store.addRecord({type: 'star', name: 'The Sun'});
+    await record.remove();
+
+    assert.ok(!cache.retrieveRecord('star', record.id), 'record does not exist in cache');
+    assert.ok(record.get('disconnected'), 'record has been disconnected from store');
+    assert.throws(() => record.get('name'), EmberError, 'record has been removed from Store');
   });
 
-  test('add to hasMany', function(assert) {
-    return EmberPromise.all([
-      store.addRecord({type: 'planet', name: 'Jupiter'}),
-      store.addRecord({type: 'moon', name: 'Callisto'})
-    ])
-      .tap(([jupiter, callisto]) => jupiter.get('moons').pushObject(callisto))
-      .then(([jupiter, callisto]) => {
-        assert.ok(jupiter.get('moons').includes(callisto), 'added record to hasMany');
-        assert.equal(callisto.get('planet'), jupiter, 'updated inverse');
-      });
+  test('add to hasMany', async function(assert) {
+    const jupiter = await store.addRecord({type: 'planet', name: 'Jupiter'});
+    const callisto = await store.addRecord({type: 'moon', name: 'Callisto'});
+
+    await jupiter.get('moons').pushObject(callisto);
+
+    assert.ok(jupiter.get('moons').includes(callisto), 'added record to hasMany');
+    assert.equal(callisto.get('planet'), jupiter, 'updated inverse');
   });
 
-  test('remove from hasMany', function(assert) {
-    return EmberPromise.all([
-      store.addRecord({type: 'planet', name: 'Jupiter'}),
-      store.addRecord({type: 'moon', name: 'Callisto'})
-    ])
-      .tap(([jupiter, callisto]) => jupiter.get('moons').pushObject(callisto))
-      .tap(([jupiter, callisto]) => jupiter.get('moons').removeObject(callisto))
-      .then(([jupiter, callisto]) => {
-        assert.ok(!jupiter.get('moons').includes(callisto), 'removed record from hasMany');
-        assert.ok(!callisto.get('planet'), 'updated inverse');
-      });
+  test('remove from hasMany', async function(assert) {
+    const jupiter = await store.addRecord({type: 'planet', name: 'Jupiter'});
+    const callisto = await store.addRecord({type: 'moon', name: 'Callisto'});
+
+    await jupiter.get('moons').pushObject(callisto);
+    await jupiter.get('moons').removeObject(callisto);
+
+    assert.ok(!jupiter.get('moons').includes(callisto), 'removed record from hasMany');
+    assert.ok(!callisto.get('planet'), 'updated inverse');
   });
 
-  test('replace hasOne with record', function(assert) {
-    return EmberPromise.all([
-      store.addRecord({type: 'planet', name: 'Jupiter'}),
-      store.addRecord({type: 'moon', name: 'Callisto'})
-    ])
-      .tap(([jupiter, callisto]) => {
-        callisto.set('planet', jupiter);
-        return store.requestQueue.process();
-      })
-      .then(([jupiter, callisto]) => {
-        assert.equal(callisto.get('planet'), jupiter, 'replaced hasOne with record');
-        assert.ok(jupiter.get('moons').includes(callisto), 'updated inverse');
-      });
+  test('replace hasOne with record', async function(assert) {
+    const jupiter = await store.addRecord({type: 'planet', name: 'Jupiter'});
+    const callisto = await store.addRecord({type: 'moon', name: 'Callisto'});
+
+    callisto.set('planet', jupiter);
+    await waitForSource(store);
+
+    assert.equal(callisto.get('planet'), jupiter, 'replaced hasOne with record');
+    assert.ok(jupiter.get('moons').includes(callisto), 'updated inverse');
   });
 
-  test('replaceRelatedRecord invalidates a relationship', function(assert) {
-    return EmberPromise.all([
-      store.addRecord({type: 'planet', name: 'Jupiter' }),
-      store.addRecord({type: 'star', name: 'Sun' })
-    ])
-      .tap(([jupiter, sun]) => {
-        jupiter.get('sun'); // cache the relationship
-        return store.source.update(t => t.replaceRelatedRecord(jupiter, 'sun', sun));
-      })
-      .then(([jupiter, sun]) => {
-        assert.equal(jupiter.get('sun'), sun, 'invalidates the relationship');
-      });
+  test('replaceRelatedRecord invalidates a relationship', async function(assert) {
+    const jupiter = await store.addRecord({type: 'planet', name: 'Jupiter' });
+    const sun = await store.addRecord({type: 'star', name: 'Sun' });
+
+    jupiter.get('sun'); // cache the relationship
+    await store.source.update(t => t.replaceRelatedRecord(jupiter, 'sun', sun));
+    assert.equal(jupiter.get('sun'), sun, 'invalidates the relationship');
   });
 
-  test('replace hasOne with null', function(assert) {
-    return EmberPromise.all([
-      store.addRecord({type: 'planet', name: 'Jupiter'}),
-      store.addRecord({type: 'moon', name: 'Callisto'})
-    ])
-      .tap(([jupiter, callisto]) => {
-        callisto.set('planet', jupiter);
-        return store.requestQueue.process();
-      })
-      .tap(([, callisto]) => {
-        callisto.set('planet', null);
-        return store.requestQueue.process();
-      })
-      .then(([jupiter, callisto]) => {
-        assert.equal(callisto.get('planet'), null, 'replaced hasOne with null');
-        assert.ok(!jupiter.get('moons').includes(callisto), 'removed from inverse hasMany');
-      });
+  test('replace hasOne with null', async function(assert) {
+    const jupiter = await store.addRecord({type: 'planet', name: 'Jupiter'});
+    const callisto = await store.addRecord({type: 'moon', name: 'Callisto'});
+
+    callisto.set('planet', jupiter);
+    await waitForSource(store);
+
+    callisto.set('planet', null);
+    await waitForSource(store);
+
+    assert.equal(callisto.get('planet'), null, 'replaced hasOne with null');
+    assert.ok(!jupiter.get('moons').includes(callisto), 'removed from inverse hasMany');
   });
 
-  test('replace attribute on model', function(assert) {
-    return store.addRecord({type: 'planet', name: 'Jupiter'})
-      .tap(record => record.set('name', 'Jupiter2'))
-      .then(record => assert.equal(record.get('name'), 'Jupiter2'));
+  test('replace attribute on model', async function(assert) {
+    const record = await store.addRecord({type: 'planet', name: 'Jupiter'});
+    record.set('name', 'Jupiter2');
+    assert.equal(record.get('name'), 'Jupiter2');
   });
 
-  test('replace attributes on model', function(assert) {
-    return store.addRecord({ type: 'planet', name: 'Jupiter' })
-      .then(record => record.replaceAttributes({ name: 'Jupiter2', classification: 'gas giant2' }))
-      .then(record => {
-        assert.equal(record.get('name'), 'Jupiter2');
-        assert.equal(record.get('classification'), 'gas giant2');
-      });
+  test('replace attributes on model', async function(assert) {
+    const record = await store.addRecord({ type: 'planet', name: 'Jupiter' });
+    await record.replaceAttributes({ name: 'Jupiter2', classification: 'gas giant2' });
+
+    assert.equal(record.get('name'), 'Jupiter2');
+    assert.equal(record.get('classification'), 'gas giant2');
   });
 
-  test('replace key', function(assert) {
-    return store.addRecord({type: 'planet', name: 'Jupiter', remoteId: 'planet:jupiter'})
-      .tap(record => record.set('remoteId', 'planet:joopiter'))
-      .then(record => assert.equal(record.get('remoteId'), 'planet:joopiter'));
+  test('replace key', async function(assert) {
+    const record = await store.addRecord({type: 'planet', name: 'Jupiter', remoteId: 'planet:jupiter'});
+    record.set('remoteId', 'planet:joopiter');
+    assert.equal(record.get('remoteId'), 'planet:joopiter');
   });
 
-  test('destroy model', function(assert) {
+  test('destroy model', async function(assert) {
     const cache = store.get('cache');
 
-    return store.addRecord({type: 'planet', name: 'Jupiter'})
-      .tap(record => record.destroy())
-      .then(record => {
-        const identifier = record.getProperties('type', 'id');
-        assert.ok(!cache.get('_identityMap').includes(identifier), 'removed from identity map');
-      });
+    const record = await store.addRecord({type: 'planet', name: 'Jupiter'});
+    const identifier = record.getProperties('type', 'id');
+    record.destroy();
+
+    await waitForSource(store);
+
+    assert.ok(!cache.get('_identityMap').includes(identifier), 'removed from identity map');
   });
 });

--- a/tests/integration/model-test.js
+++ b/tests/integration/model-test.js
@@ -83,6 +83,15 @@ module('Integration - Model', function(hooks) {
     assert.ok(!callisto.get('planet'), 'updated inverse');
   });
 
+  test('replaceRelatedRecords operation invalidates a relationship on model', async function(assert) {
+    const jupiter = await store.addRecord({type: 'planet', name: 'Jupiter'});
+    const callisto = await store.addRecord({type: 'moon', name: 'Callisto'});
+
+    assert.deepEqual(jupiter.get('moons').content, []); // cache the relationship
+    await store.source.update(t => t.replaceRelatedRecords(jupiter, 'moons', [callisto]));
+    assert.deepEqual(jupiter.get('moons').content, [callisto], 'invalidates the relationship');
+  });
+
   test('replace hasOne with record', async function(assert) {
     const jupiter = await store.addRecord({type: 'planet', name: 'Jupiter'});
     const callisto = await store.addRecord({type: 'moon', name: 'Callisto'});
@@ -94,11 +103,11 @@ module('Integration - Model', function(hooks) {
     assert.ok(jupiter.get('moons').includes(callisto), 'updated inverse');
   });
 
-  test('replaceRelatedRecord invalidates a relationship', async function(assert) {
+  test('replaceRelatedRecord operation invalidates a relationship on model', async function(assert) {
     const jupiter = await store.addRecord({type: 'planet', name: 'Jupiter' });
     const sun = await store.addRecord({type: 'star', name: 'Sun' });
 
-    jupiter.get('sun'); // cache the relationship
+    assert.equal(jupiter.get('sun'), null); // cache the relationship
     await store.source.update(t => t.replaceRelatedRecord(jupiter, 'sun', sun));
     assert.equal(jupiter.get('sun'), sun, 'invalidates the relationship');
   });
@@ -120,6 +129,13 @@ module('Integration - Model', function(hooks) {
   test('replace attribute on model', async function(assert) {
     const record = await store.addRecord({type: 'planet', name: 'Jupiter'});
     record.set('name', 'Jupiter2');
+    assert.equal(record.get('name'), 'Jupiter2');
+  });
+
+  test('replaceAttribute operation invalidates attribute on model', async function(assert) {
+    const record = await store.addRecord({type: 'planet', name: 'Jupiter'});
+    assert.equal(record.get('name'), 'Jupiter'); // cache the name
+    await store.update(t => t.replaceAttribute(record, 'name', 'Jupiter2'));
     assert.equal(record.get('name'), 'Jupiter2');
   });
 

--- a/tests/integration/model-test.js
+++ b/tests/integration/model-test.js
@@ -137,6 +137,13 @@ module('Integration - Model', function(hooks) {
     assert.equal(record.get('remoteId'), 'planet:joopiter');
   });
 
+  test('replaceKey operation invalidates key on model', async function(assert) {
+    const record = await store.addRecord({type: 'planet', name: 'Jupiter', remoteId: 'planet:jupiter'});
+    assert.equal(record.get('remoteId'), 'planet:jupiter'); // cache the key
+    await store.update(t => t.replaceKey(record, 'remoteId', 'planet:joopiter'));
+    assert.equal(record.get('remoteId'), 'planet:joopiter');
+  });
+
   test('destroy model', async function(assert) {
     const cache = store.get('cache');
 


### PR DESCRIPTION
When the `replaceKey` operation occurs in the store’s cache, the associated model must have its key CP invalidated.

Also modernizes some tests and adds others to ensure that other operations also lead to proper CP invalidation.

Fixes #174