### PR TITLE
[BREAKING] Configurable lookup paths; change default for models (`models/` -> `data-models/`)

### DIFF
--- a/addon/-private/factories/schema-factory.js
+++ b/addon/-private/factories/schema-factory.js
@@ -4,8 +4,8 @@ import { getOwner } from '@ember/application';
 import { Schema } from '@orbit/data';
 import modulesOfType from '../system/modules-of-type';
 
-function getRegisteredModels(prefix) {
-  return modulesOfType(prefix, 'models').map(camelize);
+function getRegisteredModels(prefix, modelsCollection) {
+  return modulesOfType(prefix, modelsCollection).map(camelize);
 }
 
 export default {
@@ -14,10 +14,11 @@ export default {
       const app = getOwner(injections);
       const modelSchemas = {};
 
-      let modelNames = injections.modelNames || getRegisteredModels(app.base.modulePrefix);
+      let orbitConfig = app.lookup('ember-orbit:config');
+      let modelNames = injections.modelNames || getRegisteredModels(app.base.modulePrefix, orbitConfig.collections.models);
 
       modelNames.forEach(name => {
-        let model = app.factoryFor(`model:${name}`).class;
+        let model = app.factoryFor(`${orbitConfig.types.model}:${name}`).class;
         modelSchemas[name] = {
           id: get(model, 'id'),
           keys: get(model, 'keys'),

--- a/addon/-private/identity-map.js
+++ b/addon/-private/identity-map.js
@@ -74,7 +74,9 @@ export default EmberObject.extend({
     let modelFactory = this._modelFactoryMap[type];
 
     if (!modelFactory) {
-      modelFactory = getOwner(this._store).factoryFor(`model:${type}`);
+      let owner = getOwner(this._store);
+      let orbitConfig = owner.lookup('ember-orbit:config');
+      modelFactory = owner.factoryFor(`${orbitConfig.types.model}:${type}`);
       this._modelFactoryMap[type] = modelFactory;
     }
 

--- a/addon/initializers/ember-orbit.js
+++ b/addon/initializers/ember-orbit.js
@@ -5,36 +5,65 @@ import SchemaFactory from '../-private/factories/schema-factory';
 import CoordinatorFactory from '../-private/factories/coordinator-factory';
 import KeyMapFactory from '../-private/factories/key-map-factory';
 import StoreFactory from '../-private/factories/store-factory';
+import { camelize } from '@ember/string';
+
+export const DEFAULT_ORBIT_CONFIG = {
+  types: {
+    model: 'data-model',
+    source: 'data-source',
+    strategy: 'data-strategy'
+  },
+  collections: {
+    models: 'data-models',
+    sources: 'data-sources',
+    strategies: 'data-strategies'
+  },
+  services: {
+    store: 'store',
+    coordinator: 'data-coordinator',
+    schema: 'data-schema',
+    keyMap: 'data-key-map'
+  }
+};
 
 export function initialize(application) {
   Orbit.Promise = EmberPromise;
+
+  let orbitConfig = {};
+  let config = application.resolveRegistration('config:environment') || {};
+  config.orbit = config.orbit || {};
+  ['types', 'collections', 'services'].forEach((key) => {
+    orbitConfig[key] = Object.assign({}, DEFAULT_ORBIT_CONFIG[key], config.orbit[key]);
+  });
 
   // Customize pluralization rules
   if (application.__registry__ &&
       application.__registry__.resolver &&
       application.__registry__.resolver.pluralizedTypes) {
-    application.__registry__.resolver.pluralizedTypes['data-strategy'] = 'data-strategies';
+    application.__registry__.resolver.pluralizedTypes[orbitConfig.types.model] = orbitConfig.collections.models;
+    application.__registry__.resolver.pluralizedTypes[orbitConfig.types.source] = orbitConfig.collections.sources;
+    application.__registry__.resolver.pluralizedTypes[orbitConfig.types.strategy] = orbitConfig.collections.strategies;
   }
 
-  // Schema and keymap
-  application.register('data-schema:main', SchemaFactory);
-  application.register('data-key-map:main', KeyMapFactory);
+  application.register('ember-orbit:config', orbitConfig, { instantiate: false });
 
   // Services
-  application.register('service:data-coordinator', CoordinatorFactory);
-  application.register('service:store', Store);
+  application.register(`service:${orbitConfig.services.schema}`, SchemaFactory);
+  application.register(`service:${orbitConfig.services.keyMap}`, KeyMapFactory);
+  application.register(`service:${orbitConfig.services.coordinator}`, CoordinatorFactory);
+  application.register(`service:${orbitConfig.services.store}`, Store);
 
   // Store source (which is injected in store service)
-  application.register('data-source:store', StoreFactory);
-  application.inject('service:store', 'source', 'data-source:store');
+  application.register(`${orbitConfig.types.source}:store`, StoreFactory);
+  application.inject(`service:${orbitConfig.services.store}`, 'source', `${orbitConfig.types.source}:store`);
 
   // Injections to all sources
-  application.inject('data-source', 'schema', 'data-schema:main');
-  application.inject('data-source', 'keyMap', 'data-key-map:main');
+  application.inject(orbitConfig.types.source, 'schema', `service:${orbitConfig.services.schema}`);
+  application.inject(orbitConfig.types.source, 'keyMap', `service:${orbitConfig.services.keyMap}`);
 
   // Injections to application elements
-  application.inject('route', 'store', 'service:store');
-  application.inject('controller', 'store', 'service:store');
+  application.inject('route', camelize(orbitConfig.services.store), `service:${orbitConfig.services.store}`);
+  application.inject('controller', camelize(orbitConfig.services.store), `service:${orbitConfig.services.store}`);
 }
 
 export default {

--- a/tests/integration/config-test.js
+++ b/tests/integration/config-test.js
@@ -1,0 +1,57 @@
+// import EmberError from '@ember/error';
+// import EmberObject from '@ember/object';
+import { Planet, Moon, Star } from 'dummy/tests/support/dummy-models';
+import { createOwner, createStore } from 'dummy/tests/support/store';
+import { module, test } from 'qunit';
+// import { getOwner } from '@ember/application';
+// import { waitForSource } from 'ember-orbit/test-support';
+import Controller from '@ember/controller';
+import Route from '@ember/routing/route';
+
+module('Integration - Config', function(hooks) {
+  let owner;
+  let store;
+
+  hooks.beforeEach(function() {
+    owner = createOwner();
+    owner.register('config:environment', {
+      orbit: {
+        types: {
+          model: 'orbit-model',
+          source: 'orbit-source',
+          strategy: 'orbit-strategy'
+        },
+        collections: {
+          models: 'orbit-models',
+          sources: 'orbit-sources',
+          strategies: 'orbit-strategies'
+        },
+        services: {
+          store: 'orbit-store',
+          coordinator: 'orbit-coordinator',
+          schema: 'data-schema',
+          keyMap: 'orbit-key-map'
+        }
+      }
+    }, { instantiate: false });
+    const models = { planet: Planet, moon: Moon, star: Star };
+    store = createStore({ models, owner });
+    owner.register('controller:application', Controller);
+    owner.register('route:application', Route);
+  });
+
+  hooks.afterEach(function() {
+    store = null;
+    owner = null;
+  });
+
+  test('registrations respect config', async function(assert) {
+    assert.equal(owner.lookup('service:orbit-store'), store, 'store service registration is named from configuration');
+    assert.ok(owner.resolveRegistration('orbit-model:planet'), 'model factory registration is named from configuration');
+    assert.ok(owner.lookup('orbit-source:store'), 'source registation is named from configuration');
+    assert.ok(owner.lookup('orbit-source:store').schema, 'schema is injected successfully on sources');
+    assert.ok(owner.lookup('service:data-schema'), 'unconfigured lookup type falls back to default configuration');
+    assert.equal(owner.lookup('controller:application').orbitStore, store, 'configured store name is camelized for controller and route injection');
+    assert.equal(owner.lookup('route:application').orbitStore, store, 'configured store name is camelized for controller and route injection');
+  });
+});

--- a/tests/integration/model-test.js
+++ b/tests/integration/model-test.js
@@ -31,7 +31,7 @@ module('Integration - Model', function(hooks) {
 
     const app = getOwner(store);
     app.register('service:foo', Foo);
-    app.inject('model:star', 'foo', 'service:foo');
+    app.inject('data-model:star', 'foo', 'service:foo');
 
     const model = await store.addRecord({type: 'star', name: 'The Sun'});
     assert.ok(model.get('foo'), 'service has been injected');

--- a/yarn.lock
+++ b/yarn.lock
@@ -79,39 +79,59 @@
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.2.tgz#54c5a964462be3d4d78af631363c18d6fa91ac26"
 
-"@orbit/coordinator@^0.15.23":
-  version "0.15.23"
-  resolved "https://registry.yarnpkg.com/@orbit/coordinator/-/coordinator-0.15.23.tgz#aac121bb61d794018e0069c39b8fb24b0abf5e7d"
-
-"@orbit/core@^0.15.23":
-  version "0.15.23"
-  resolved "https://registry.yarnpkg.com/@orbit/core/-/core-0.15.23.tgz#3f6656f37d6bf9bdf5ef03ae26726cb8ba03776d"
+"@orbit/coordinator@^0.16.0-beta.1":
+  version "0.16.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@orbit/coordinator/-/coordinator-0.16.0-beta.1.tgz#12697a20028302f08830a918c72035fa570dafd2"
+  integrity sha512-EayPyFVZr3TiuRaWKPZoTumMkzDbaleZd97j+JV+WjDLLh0R6Z9k7QO/GETvRag6au9MtCDxPvRL4cqfIIC2hA==
   dependencies:
-    "@orbit/utils" "^0.15.23"
+    "@orbit/core" "^0.16.0-beta.1"
+    "@orbit/data" "^0.16.0-beta.1"
+    "@orbit/utils" "^0.16.0-beta.1"
 
-"@orbit/data@^0.15.23":
-  version "0.15.23"
-  resolved "https://registry.yarnpkg.com/@orbit/data/-/data-0.15.23.tgz#5b71585d65d4b96b9e79e0feb281f4c957547307"
+"@orbit/core@^0.16.0-beta.1":
+  version "0.16.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@orbit/core/-/core-0.16.0-beta.1.tgz#4065e5e70c65aa20da48db4ee51c6d40a2368724"
+  integrity sha512-V3CCyl+o1UF/paSRy4+wqU2H55OuDsGpQSbkRVpHt2mlJiMASO6iYH/q1oKEi1jpATr+2ubN9dVzfLztY+i5Ng==
   dependencies:
-    "@orbit/core" "^0.15.23"
-    "@orbit/utils" "^0.15.23"
+    "@orbit/utils" "^0.16.0-beta.1"
 
-"@orbit/immutable@^0.15.23":
-  version "0.15.23"
-  resolved "https://registry.yarnpkg.com/@orbit/immutable/-/immutable-0.15.23.tgz#728ad2d3901a1a5db15be62dddce301f0341502e"
-
-"@orbit/store@^0.15.23":
-  version "0.15.23"
-  resolved "https://registry.yarnpkg.com/@orbit/store/-/store-0.15.23.tgz#6d8a0260b30ed72b135df108e17f959bcb28414f"
+"@orbit/data@^0.16.0-beta.1":
+  version "0.16.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@orbit/data/-/data-0.16.0-beta.1.tgz#2ea5ffe4605d1f990837f9cfe72f57ad13e08e85"
+  integrity sha512-cdt+3XN/YLN0GDK6WZeeCueqIiimnMPBBznw/EeW1eIMmHT3e9WP+JzuaOsm/j8IKUm2hYhLmonAl0/DV9fj/Q==
   dependencies:
-    "@orbit/core" "^0.15.23"
-    "@orbit/data" "^0.15.23"
-    "@orbit/immutable" "^0.15.23"
-    "@orbit/utils" "^0.15.23"
+    "@orbit/core" "^0.16.0-beta.1"
+    "@orbit/utils" "^0.16.0-beta.1"
 
-"@orbit/utils@^0.15.23":
-  version "0.15.23"
-  resolved "https://registry.yarnpkg.com/@orbit/utils/-/utils-0.15.23.tgz#3c3c00414e9a0a8aa3b1907025e30ca31b98e65b"
+"@orbit/immutable@^0.16.0-beta.1":
+  version "0.16.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@orbit/immutable/-/immutable-0.16.0-beta.1.tgz#c24c8513206ac24a9acaae9c2974f19b6fd73be9"
+  integrity sha512-lK/2BamKuvYac/zErBFDboTTdxfS6Sz4ajKyD3UCSuWFd1s89L3yv3QvjXLux+IHm5IaO3CiLuObEeVaWsvTaA==
+
+"@orbit/record-cache@^0.16.0-beta.3":
+  version "0.16.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@orbit/record-cache/-/record-cache-0.16.0-beta.3.tgz#5a5c5fd4d3d81c5f31982955c7ad351a47037809"
+  integrity sha512-psnE5H1D2HBDt0Gf61x3jFJYrxN/NCyB4kOMRS0yOF09Hu8pcbyZj/hR63VpZ2e80LmmJ50xkaZJUGa/SAAJ8w==
+  dependencies:
+    "@orbit/core" "^0.16.0-beta.1"
+    "@orbit/data" "^0.16.0-beta.1"
+    "@orbit/utils" "^0.16.0-beta.1"
+
+"@orbit/store@^0.16.0-beta.2":
+  version "0.16.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@orbit/store/-/store-0.16.0-beta.3.tgz#737bbe523e833e11538479d8c59a3ab4b4c0bae1"
+  integrity sha512-p8llN5gRxaBQIuhQxshpuvNpfqdwQrZfAZc8pHaTbLOpVb6VZmvmFHZVsSm3XsnPjnUTYxJ3v8GPmD55J7QdDg==
+  dependencies:
+    "@orbit/core" "^0.16.0-beta.1"
+    "@orbit/data" "^0.16.0-beta.1"
+    "@orbit/immutable" "^0.16.0-beta.1"
+    "@orbit/record-cache" "^0.16.0-beta.3"
+    "@orbit/utils" "^0.16.0-beta.1"
+
+"@orbit/utils@^0.16.0-beta.1":
+  version "0.16.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@orbit/utils/-/utils-0.16.0-beta.1.tgz#08d2ed5bd1216f353c7d621b694a17ad8bf24243"
+  integrity sha512-S8rp47/xQmBx+ub0Y1a7DQcKA+OQwXpv8vNAhMqw+Ew0sDUHYaeRibSsgCGDatC3UkP8ClUVFHgJifS19jxDPQ==
 
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"


### PR DESCRIPTION
This commit adds support for configuring how ember-orbit will lookup the modules
it uses and how it injects them into your app. It is configured under an orbit entry in
config/environment.js. The default values are:

```
orbit: {
  types: {
    model: 'data-model',
    source: 'data-source',
    strategy: 'data-strategy'
  },
  collections: {
    models: 'data-models',
    sources: 'data-sources',
    strategies: 'data-strategies'
  },
  services: {
    store: 'store',
    coordinator: 'data-coordinator',
    schema: 'data-schema',
    keyMap: 'data-key-map'
  }
}
```

 - `types` controls naming in ember's container.
 - `collections` controls naming in ember's module/filesystem. Currently,
   collections should be the plural version of the corresponding type
 - `services` controls naming of the services that ember-orbit provides
   and the properties they are injected onto

Setting `orbit.types.model` to `data-model` and `orbit.collections.models`
to `data-models` means that you would put your orbit model classes in files within
`app/data-models/`. This is a breaking change from 0.15, where they were looked up within
`app/models/`. This change was made for consistency and to make ember-orbit better able to
co-exist with ember-data in an app. In order to restore the 0.15 behavior, use the following
config:

```
orbit: {
  types: {
    model: 'model'
  },
  collections: {
    models: 'models'
  }
}
```

The `services` config nodes determines what name is used when injecting
the ember-orbit store service onto routes and controllers. If you want
to avoid a conflict with ember-data's injections, change this value. e.g.

```
orbit: {
  services: {
    store: 'orbit-store'
  }
}
```

Note that service names are camelized when injecting, so a value of `orbit-store`
would be injected as `orbitStore`

## summary from the first revision

<details><summary>Reveal</summary>

This commit adds support for configuring how ember-orbit will lookup the modules
it uses and how it injects them into your app. It is configured under an orbit entry in
config/environment.js. The default values are:

```
  orbit: {
    modelType: 'data-model',
    strategyType: 'data-strategy',
    sourceType: 'data-source',
    schemaType: 'data-schema',
    keyMapType: 'data-key-map',
    storeName: 'store',
    dataCoordinatorName: 'data-coordinator'
  }
```

A modelType of `data-model` means that you would put your orbit model classes in files within
`app/data-models/`. This is a breaking change from 0.15, where they were looked up within
`app/models/`. This change was made for consistency and to make ember-orbit better able to
co-exist with ember-data in an app. In order to restore the 0.15 behavior, use the following
config:

```
  orbit: {
    modelType: 'model'
  }
```

The `storeName` and `dataCoordinateName` config determines what name is used when injecting
the ember-orbit store service onto routes and controllers. If you want to avoid a conflict
with ember-data's injections, change this value. e.g.

```
  orbit: {
    storeName: 'orbitStore'
  }
```
</details>