### PR TITLE
Provide convenient access to underlying record data via ember-orbit model

### DIFF
--- a/addon/-private/cache.js
+++ b/addon/-private/cache.js
@@ -18,13 +18,17 @@ export default EmberObject.extend({
   },
 
   includesRecord(type, id) {
-    return !!this._sourceCache.getRecordSync({ type, id });
+    return !!this.retrieveRecordData(type, id);
   },
 
   retrieveRecord(type, id) {
     if (this.includesRecord(type, id)) {
       return this._identityMap.lookup({type, id});
     }
+  },
+
+  retrieveRecordData(type, id) {
+    return this._sourceCache.getRecordSync({ type, id });
   },
 
   retrieveKey(recordIdentity, key) {

--- a/addon/-private/model.js
+++ b/addon/-private/model.js
@@ -37,6 +37,11 @@ const Model = EmberObject.extend(Evented, {
     store.update(t => t.replaceAttribute(this.identity, attribute, value), options);
   },
 
+  getData() {
+    const cache = get(this, '_storeOrError.cache');
+    return cache.retrieveRecordData(this.type, this.id);
+  },
+
   getRelatedRecord(relationship) {
     const cache = get(this, '_storeOrError.cache');
     return cache.retrieveRelatedRecord(this.identity, relationship);

--- a/tests/integration/cache-test.js
+++ b/tests/integration/cache-test.js
@@ -147,6 +147,19 @@ module('Integration - Cache', function(hooks) {
     });
   });
 
+  test('#retrieveRecordData', function(assert) {
+    const done = assert.async();
+    run(() => {
+      store
+        .addRecord({type: 'planet', name: 'Jupiter'})
+        .then((record) => cache.retrieveRecordData('planet', record.get('id')))
+        .then((retrievedRecordData) => {
+          assert.ok(retrievedRecordData, 'retrieved record data');
+          assert.equal(retrievedRecordData.attributes.name, 'Jupiter', 'retrieved record data has attribute value');
+        }).then(() => done());
+    });
+  });
+
   test('#query - record', function(assert) {
     let earth;
 

--- a/tests/integration/model-test.js
+++ b/tests/integration/model-test.js
@@ -171,4 +171,10 @@ module('Integration - Model', function(hooks) {
 
     assert.ok(!cache.get('_identityMap').includes(identifier), 'removed from identity map');
   });
+
+  test('getData returns underlying record data', async function(assert){
+    const record = await store.addRecord({type: 'planet', name: 'Jupiter'});
+    let recordData = record.getData();
+    assert.equal(recordData.attributes.name, 'Jupiter', 'returns record data (resource)');
+  });
 });


### PR DESCRIPTION
- Introduces two new methods:
    - `Cache#retrieveRecordData(type, id)`
    - `Model#getData()`

Both return the record data that is typed in Orbit as a "Resource". It can also be understood as JSON:API-compatible JSON.

The real-world use case that prompted the addition of this API was the desire to serialize an ember-orbit model to JSON:API. With this commit, that can be accomplished like so:

```js
import { JSONAPISerializer } from '@orbit/jsonapi';

let serializer = new JSONApiSerializer(...);
return serializer.serializeRecord(model.getData());
```