### PR TITLE
Fix management of HasMany relationships

### DIFF
--- a/addon/-private/live-query.js
+++ b/addon/-private/live-query.js
@@ -7,15 +7,17 @@ export default ReadOnlyArrayProxy.extend({
 
   init(...args) {
     this._super(...args);
-    this._sourceCache.on('patch', this.invalidate.bind(this));
-    this._sourceCache.on('reset', this.invalidate.bind(this));
+    this._invalidatelistener = this.invalidate.bind(this);
+    this._sourceCache.on('patch', this._invalidatelistener);
+    this._sourceCache.on('reset', this._invalidatelistener);
   },
 
   willDestroy(...args) {
     this._super(...args);
-    this._sourceCache.off('patch', this.invalidate.bind(this));
-    this._sourceCache.off('reset', this.invalidate.bind(this));
-  },
+    this._sourceCache.off('patch', this._invalidatelistener);
+    this._sourceCache.off('reset', this._invalidatelistener);
+    this._invalidatelistener = null;
+},
 
   invalidate() {
     set(this, '_content', null);

--- a/addon/-private/model.js
+++ b/addon/-private/model.js
@@ -54,12 +54,16 @@ const Model = EmberObject.extend(Evented, {
   },
 
   getRelatedRecords(field) {
-    const store = get(this, '_storeOrError');
-    return HasMany.create({
-      _store: store,
-      _model: this,
-      _relationship: field
-    });
+    this._relatedRecords = this._relatedRecords || {};
+    if (!this._relatedRecords[field]) {
+      const store = get(this, '_storeOrError');
+      this._relatedRecords[field] = HasMany.create({
+        _store: store,
+        _model: this,
+        _relationship: field
+      });
+    }
+    return this._relatedRecords[field];
   },
 
   replaceAttributes(properties, options) {

--- a/addon/-private/model.js
+++ b/addon/-private/model.js
@@ -79,6 +79,13 @@ const Model = EmberObject.extend(Evented, {
   },
 
   disconnect() {
+    // destroy any LiveQuery relationships associated with this record
+    if (this._relatedRecords) {
+      for (let rel in this._relatedRecords) {
+        this._relatedRecords[rel].destroy();
+        delete this._relatedRecords[rel];
+      }
+    }
     set(this, '_store', null);
   },
 

--- a/tests/integration/model-test.js
+++ b/tests/integration/model-test.js
@@ -53,13 +53,22 @@ module('Integration - Model', function(hooks) {
 
   test('remove model', async function(assert) {
     const cache = store.cache;
-
     const record = await store.addRecord({type: 'star', name: 'The Sun'});
     await record.remove();
 
     assert.ok(!cache.retrieveRecord('star', record.id), 'record does not exist in cache');
     assert.ok(record.get('disconnected'), 'record has been disconnected from store');
     assert.throws(() => record.get('name'), EmberError, 'record has been removed from Store');
+  });
+
+  test('remove model with relationships', async function(assert) {
+    const callisto = await store.addRecord({type: 'moon', name: 'Callisto'});
+    const sun = await store.addRecord({type: 'star', name: 'Sun' });
+    const jupiter = await store.addRecord({type: 'planet', name: 'Jupiter', moons: [callisto], sun});
+    assert.deepEqual(jupiter.moons.content, [callisto], 'moons relationship has been added');
+    assert.strictEqual(jupiter.sun, sun, 'sun relationship has been added');
+
+    await jupiter.remove();
   });
 
   test('add to hasMany', async function(assert) {

--- a/tests/integration/model-test.js
+++ b/tests/integration/model-test.js
@@ -177,4 +177,13 @@ module('Integration - Model', function(hooks) {
     let recordData = record.getData();
     assert.equal(recordData.attributes.name, 'Jupiter', 'returns record data (resource)');
   });
+
+  test('getRelatedRecords always returns the same LiveQuery', async function(assert) {
+    const callisto = await store.addRecord({type: 'moon', name: 'Callisto'});
+    const sun = await store.addRecord({type: 'star', name: 'Sun' });
+    const jupiter = await store.addRecord({type: 'planet', name: 'Jupiter', moons: [callisto], sun});
+    assert.deepEqual(jupiter.moons.content, [callisto], 'moons relationship has been added');
+    assert.strictEqual(jupiter.moons, jupiter.getRelatedRecords('moons'), 'getRelatedRecords returns the expected LiveQuery');
+    assert.strictEqual(jupiter.getRelatedRecords('moons'), jupiter.getRelatedRecords('moons'), 'getRelatedRecords does not create additional LiveQueries');
+  });
 });


### PR DESCRIPTION
This solves several issues related to LiveQueries, especially when used to manage has-many relationships:

* A potential memory leak has been fixed related to clearing event listeners.
* `Model#getRelatedRecords` now caches any LiveQueries for has-many relationships. This would have only been an issue if called directly, which would have been rare.
* `Model#disconnect` now clears any `LiveQuery`s maintained for has-many relationships.

Fixes #179 
