### PR TITLE
Modernize and standardize Store + Cache interfaces

### DIFF
--- a/addon/-private/cache.ts
+++ b/addon/-private/cache.ts
@@ -18,7 +18,7 @@ import Model from './model';
 import ModelFactory from './model-factory';
 import recordIdentitySerializer from './utils/record-identity-serializer';
 
-const { deprecate } = Orbit;
+const { assert, deprecate } = Orbit;
 
 export interface CacheSettings {
   sourceCache: MemoryCache;
@@ -96,6 +96,20 @@ export default class Cache {
   peekRecords(type: string): Model[] {
     const identities = this._sourceCache.getRecordsSync(type);
     return this.lookup(identities) as Model[];
+  }
+
+  recordIdFromKey(type: string, keyName: string, keyValue: string): string {
+    let keyMap = this.keyMap as KeyMap;
+    assert(
+      'No `keyMap` has been assigned to the Cache, so `recordIdFromKey` can not work.',
+      !!keyMap
+    );
+    let id = keyMap.keyToId(type, keyName, keyValue);
+    if (!id) {
+      id = this.schema.generateId(type);
+      keyMap.pushRecord({ type, id, keys: { [keyName]: keyValue } });
+    }
+    return id;
   }
 
   /**

--- a/addon/-private/cache.ts
+++ b/addon/-private/cache.ts
@@ -1,5 +1,4 @@
 import { notifyPropertyChange } from '@ember/object';
-
 import { Listener } from '@orbit/core';
 import { deepGet } from '@orbit/utils';
 import Orbit, {
@@ -7,12 +6,13 @@ import Orbit, {
   RecordIdentity,
   QueryOrExpression,
   RecordOperation,
-  Record
+  Record,
+  KeyMap,
+  Schema
 } from '@orbit/data';
 import { QueryResultData } from '@orbit/record-cache';
 import { MemoryCache } from '@orbit/memory';
 import IdentityMap from '@orbit/identity-map';
-
 import LiveQuery from './live-query';
 import Model from './model';
 import ModelFactory from './model-factory';
@@ -48,6 +48,14 @@ export default class Cache {
 
     this._sourceCache.on('patch', this._patchListener);
     this._sourceCache.on('reset', this._resetListener);
+  }
+
+  get keyMap(): KeyMap | undefined {
+    return this._sourceCache.keyMap;
+  }
+
+  get schema(): Schema {
+    return this._sourceCache.schema;
   }
 
   /**

--- a/addon/-private/cache.ts
+++ b/addon/-private/cache.ts
@@ -85,6 +85,11 @@ export default class Cache {
     return undefined;
   }
 
+  peekRecords(type: string): Model[] {
+    const identities = this._sourceCache.getRecordsSync(type);
+    return this.lookup(identities) as Model[];
+  }
+
   /**
    * @deprecated
    */

--- a/addon/-private/cache.ts
+++ b/addon/-private/cache.ts
@@ -98,6 +98,14 @@ export default class Cache {
     return this.lookup(identities) as Model[];
   }
 
+  peekRecordByKey(
+    type: string,
+    keyName: string,
+    keyValue: string
+  ): Model | undefined {
+    return this.peekRecord(type, this.recordIdFromKey(type, keyName, keyValue));
+  }
+
   recordIdFromKey(type: string, keyName: string, keyValue: string): string {
     let keyMap = this.keyMap as KeyMap;
     assert(

--- a/addon/-private/cache.ts
+++ b/addon/-private/cache.ts
@@ -50,32 +50,86 @@ export default class Cache {
     this._sourceCache.on('reset', this._resetListener);
   }
 
+  /**
+   * @deprecated
+   */
   retrieveRecordData(type: string, id: string): Record | undefined {
+    deprecate(
+      '`Cache#retrieveRecordData(type, id)` is deprecated, use `Cache#peekRecordData(type, id)`.'
+    );
+    return this.peekRecordData(type, id);
+  }
+
+  peekRecordData(type: string, id: string): Record | undefined {
     return this._sourceCache.getRecordSync({ type, id });
   }
 
   includesRecord(type: string, id: string): boolean {
-    return !!this.retrieveRecordData(type, id);
+    return !!this.peekRecordData(type, id);
   }
 
+  /**
+   * @deprecated
+   */
   retrieveRecord(type: string, id: string): Model | undefined {
+    deprecate(
+      '`Cache#retrieveRecord(type, id)` is deprecated, use `Cache#peekRecord(type, id)`.'
+    );
+    return this.peekRecord(type, id);
+  }
+
+  peekRecord(type: string, id: string): Model | undefined {
     if (this.includesRecord(type, id)) {
       return this.lookup({ type, id }) as Model;
     }
     return undefined;
   }
 
+  /**
+   * @deprecated
+   */
   retrieveKey(identity: RecordIdentity, key: string): string | undefined {
+    deprecate(
+      '`Cache#retrieveKey(identity, key)` is deprecated, use `Cache#peekKey(identity, key)`.'
+    );
+    return this.peekKey(identity, key);
+  }
+
+  peekKey(identity: RecordIdentity, key: string): string | undefined {
     const record = this._sourceCache.getRecordSync(identity);
     return record && deepGet(record, ['keys', key]);
   }
 
+  /**
+   * @deprecated
+   */
   retrieveAttribute(identity: RecordIdentity, attribute: string): any {
+    deprecate(
+      '`Cache#retrieveAttribute(identity, attribute)` is deprecated, use `Cache#peekAttribute(identity, key)`.'
+    );
     const record = this._sourceCache.getRecordSync(identity);
     return record && deepGet(record, ['attributes', attribute]);
   }
 
+  peekAttribute(identity: RecordIdentity, attribute: string): any {
+    const record = this._sourceCache.getRecordSync(identity);
+    return record && deepGet(record, ['attributes', attribute]);
+  }
+
+  /**
+   * @deprecated
+   */
   retrieveRelatedRecord(
+    identity: RecordIdentity,
+    relationship: string
+  ): Model | null | undefined {
+    deprecate(
+      '`Cache#retrieveRelatedRecord(identity, relationship)` is deprecated, use `Cache#peekRelatedRecord(identity, relationship)`.'
+    );
+    return this.peekRelatedRecord(identity, relationship);
+  }
+
+  peekRelatedRecord(
     identity: RecordIdentity,
     relationship: string
   ): Model | null | undefined {
@@ -90,7 +144,20 @@ export default class Cache {
     }
   }
 
+  /**
+   * @deprecated
+   */
   retrieveRelatedRecords(
+    identity: RecordIdentity,
+    relationship: string
+  ): Model[] | undefined {
+    deprecate(
+      '`Cache#retrieveRelatedRecords(identity, relationship)` is deprecated, use `Cache#peekRelatedRecords(identity, relationship)`.'
+    );
+    return this.peekRelatedRecords(identity, relationship);
+  }
+
+  peekRelatedRecords(
     identity: RecordIdentity,
     relationship: string
   ): Model[] | undefined {

--- a/addon/-private/cache.ts
+++ b/addon/-private/cache.ts
@@ -8,7 +8,8 @@ import Orbit, {
   RecordOperation,
   Record,
   KeyMap,
-  Schema
+  Schema,
+  TransformBuilder
 } from '@orbit/data';
 import { QueryResultData } from '@orbit/record-cache';
 import { MemoryCache } from '@orbit/memory';
@@ -56,6 +57,10 @@ export default class Cache {
 
   get schema(): Schema {
     return this._sourceCache.schema;
+  }
+
+  get transformBuilder(): TransformBuilder {
+    return this._sourceCache.transformBuilder;
   }
 
   /**

--- a/addon/-private/model.ts
+++ b/addon/-private/model.ts
@@ -43,11 +43,11 @@ export default class Model extends EmberObject {
   }
 
   getData(): Record | undefined {
-    return this.store.cache.retrieveRecordData(this.type, this.id);
+    return this.store.cache.peekRecordData(this.type, this.id);
   }
 
   getKey(field: string): string | undefined {
-    return this.store.cache.retrieveKey(this.identity, field);
+    return this.store.cache.peekKey(this.identity, field);
   }
 
   async replaceKey(
@@ -62,7 +62,7 @@ export default class Model extends EmberObject {
   }
 
   getAttribute(field: string): any {
-    return this.store.cache.retrieveAttribute(this.identity, field);
+    return this.store.cache.peekAttribute(this.identity, field);
   }
 
   async replaceAttribute(
@@ -77,7 +77,7 @@ export default class Model extends EmberObject {
   }
 
   getRelatedRecord(relationship: string): Record | null | undefined {
-    return this.store.cache.retrieveRelatedRecord(this.identity, relationship);
+    return this.store.cache.peekRelatedRecord(this.identity, relationship);
   }
 
   async replaceRelatedRecord(
@@ -102,7 +102,7 @@ export default class Model extends EmberObject {
     if (!this._relatedRecords[relationship]) {
       this._relatedRecords[relationship] = HasMany.create({
         getContent: () =>
-          this.store.cache.retrieveRelatedRecords(this.identity, relationship),
+          this.store.cache.peekRelatedRecords(this.identity, relationship),
         addToContent: (record: Model): Promise<void> => {
           return this.addToRelatedRecords(relationship, record);
         },

--- a/addon/-private/store.ts
+++ b/addon/-private/store.ts
@@ -9,7 +9,8 @@ import {
   cloneRecordIdentity,
   RecordOperation,
   KeyMap,
-  Schema
+  Schema,
+  TransformBuilder
 } from '@orbit/data';
 import MemorySource from '@orbit/memory';
 import Orbit, { Log, TaskQueue, Listener } from '@orbit/core';
@@ -28,10 +29,6 @@ export default class Store {
   source: MemorySource;
   cache: Cache;
 
-  transformLog: Log;
-  requestQueue: TaskQueue;
-  syncQueue: TaskQueue;
-
   static create(injections: StoreSettings): Store {
     const owner = getOwner(injections);
     const store = new this(injections);
@@ -46,20 +43,12 @@ export default class Store {
       sourceCache: this.source.cache,
       modelFactory: new ModelFactory(this)
     });
-
-    this.transformLog = this.source.transformLog;
-    this.requestQueue = this.source.requestQueue;
-    this.syncQueue = this.source.syncQueue;
   }
 
   destroy() {
     this.cache.destroy();
-
     delete this.source;
     delete this.cache;
-    delete this.transformLog;
-    delete this.requestQueue;
-    delete this.syncQueue;
   }
 
   get keyMap(): KeyMap | undefined {
@@ -68,6 +57,22 @@ export default class Store {
 
   get schema(): Schema {
     return this.source.schema;
+  }
+
+  get transformBuilder(): TransformBuilder {
+    return this.source.transformBuilder;
+  }
+
+  get transformLog(): Log {
+    return this.source.transformLog;
+  }
+
+  get requestQueue(): TaskQueue {
+    return this.source.requestQueue;
+  }
+
+  get syncQueue(): TaskQueue {
+    return this.source.syncQueue;
   }
 
   fork(): Store {

--- a/addon/-private/store.ts
+++ b/addon/-private/store.ts
@@ -154,14 +154,6 @@ export default class Store {
     return this.query(q => q.findRecords(type), options);
   }
 
-  peekRecord(type: string, id: string): Model | undefined {
-    return this.cache.peekRecord(type, id);
-  }
-
-  peekRecords(type: string): Model[] {
-    return this.cache.peekRecords(type);
-  }
-
   findRecordByKey(
     type: string,
     keyName: string,
@@ -173,6 +165,22 @@ export default class Store {
       this.cache.recordIdFromKey(type, keyName, keyValue),
       options
     );
+  }
+
+  peekRecord(type: string, id: string): Model | undefined {
+    return this.cache.peekRecord(type, id);
+  }
+
+  peekRecords(type: string): Model[] {
+    return this.cache.peekRecords(type);
+  }
+
+  peekRecordByKey(
+    type: string,
+    keyName: string,
+    keyValue: string
+  ): Model | undefined {
+    return this.cache.peekRecordByKey(type, keyName, keyValue);
   }
 
   on(event: string, listener: Listener): void {

--- a/addon/-private/store.ts
+++ b/addon/-private/store.ts
@@ -85,6 +85,10 @@ export default class Store {
     return this.source.rollback(transformId, relativePosition);
   }
 
+  rebase(): void {
+    this.source.rebase();
+  }
+
   liveQuery(
     queryOrExpression: QueryOrExpression,
     options?: object,
@@ -205,6 +209,14 @@ export default class Store {
     id?: string
   ): Promise<any> {
     return this.source.update(transformOrTransforms, options, id);
+  }
+
+  transformsSince(transformId: string): Transform[] {
+    return this.source.transformsSince(transformId);
+  }
+
+  allTransforms(): Transform[] {
+    return this.source.allTransforms();
   }
 
   getTransform(transformId: string): Transform {

--- a/addon/-private/store.ts
+++ b/addon/-private/store.ts
@@ -7,7 +7,9 @@ import {
   Transform,
   TransformOrOperations,
   cloneRecordIdentity,
-  RecordOperation
+  RecordOperation,
+  KeyMap,
+  Schema
 } from '@orbit/data';
 import MemorySource from '@orbit/memory';
 import Orbit, { Log, TaskQueue, Listener } from '@orbit/core';
@@ -58,6 +60,14 @@ export default class Store {
     delete this.transformLog;
     delete this.requestQueue;
     delete this.syncQueue;
+  }
+
+  get keyMap(): KeyMap | undefined {
+    return this.source.keyMap;
+  }
+
+  get schema(): Schema {
+    return this.source.schema;
   }
 
   fork(): Store {

--- a/addon/-private/store.ts
+++ b/addon/-private/store.ts
@@ -26,8 +26,8 @@ export interface StoreSettings {
 }
 
 export default class Store {
-  source: MemorySource;
-  cache: Cache;
+  private _source: MemorySource;
+  private _cache: Cache;
 
   static create(injections: StoreSettings): Store {
     const owner = getOwner(injections);
@@ -37,18 +37,26 @@ export default class Store {
   }
 
   constructor(settings: StoreSettings) {
-    this.source = settings.source;
+    this._source = settings.source;
 
-    this.cache = new Cache({
+    this._cache = new Cache({
       sourceCache: this.source.cache,
       modelFactory: new ModelFactory(this)
     });
   }
 
   destroy() {
-    this.cache.destroy();
-    delete this.source;
-    delete this.cache;
+    this._cache.destroy();
+    delete this._source;
+    delete this._cache;
+  }
+
+  get source(): MemorySource {
+    return this._source;
+  }
+
+  get cache(): Cache {
+    return this._cache;
   }
 
   get keyMap(): KeyMap | undefined {

--- a/tests/integration/cache-test.js
+++ b/tests/integration/cache-test.js
@@ -86,89 +86,83 @@ module('Integration - Cache', function(hooks) {
     assert.notOk(planets.includes(jupiter));
   });
 
-  test('#retrieveRecord - existing record', async function(assert) {
+  test('#peekRecord - existing record', async function(assert) {
     const jupiter = await store.addRecord({ type: 'planet', name: 'Jupiter' });
     assert.strictEqual(
-      cache.retrieveRecord('planet', jupiter.id),
+      cache.peekRecord('planet', jupiter.id),
       jupiter,
       'retrieved record'
     );
   });
 
-  test('#retrieveRecord - missing record', async function(assert) {
-    assert.strictEqual(cache.retrieveRecord('planet', 'fake'), undefined);
+  test('#peekRecord - missing record', async function(assert) {
+    assert.strictEqual(cache.peekRecord('planet', 'fake'), undefined);
   });
 
-  test('#retrieveKey - existing record + key', async function(assert) {
+  test('#peekKey - existing record + key', async function(assert) {
     const jupiter = await store.addRecord({ type: 'planet', remoteId: '123' });
-    assert.equal(cache.retrieveKey(jupiter, 'remoteId'), '123');
+    assert.equal(cache.peekKey(jupiter, 'remoteId'), '123');
   });
 
-  test('#retrieveKey - missing record', async function(assert) {
+  test('#peekKey - missing record', async function(assert) {
     assert.strictEqual(
-      cache.retrieveKey({ type: 'planet', id: 'fake' }, 'remoteId'),
+      cache.peekKey({ type: 'planet', id: 'fake' }, 'remoteId'),
       undefined
     );
   });
 
-  test('#retrieveKey - existing record, missing key', async function(assert) {
+  test('#peekKey - existing record, missing key', async function(assert) {
     const jupiter = await store.addRecord({ type: 'planet', name: 'Jupiter' });
-    assert.strictEqual(cache.retrieveKey(jupiter, 'fake'), undefined);
+    assert.strictEqual(cache.peekKey(jupiter, 'fake'), undefined);
   });
 
-  test('#retrieveAttribute - existing record + attribute', async function(assert) {
+  test('#peekAttribute - existing record + attribute', async function(assert) {
     const jupiter = await store.addRecord({ type: 'planet', name: 'Jupiter' });
-    assert.equal(cache.retrieveAttribute(jupiter, 'name'), 'Jupiter');
+    assert.equal(cache.peekAttribute(jupiter, 'name'), 'Jupiter');
   });
 
-  test('#retrieveAttribute - missing record', async function(assert) {
+  test('#peekAttribute - missing record', async function(assert) {
     assert.strictEqual(
-      cache.retrieveAttribute({ type: 'planet', id: 'fake' }, 'name'),
+      cache.peekAttribute({ type: 'planet', id: 'fake' }, 'name'),
       undefined
     );
   });
 
-  test('#retrieveAttribute - existing record, missing attribute', async function(assert) {
+  test('#peekAttribute - existing record, missing attribute', async function(assert) {
     const jupiter = await store.addRecord({ type: 'planet', name: 'Jupiter' });
-    assert.strictEqual(cache.retrieveAttribute(jupiter, 'fake'), undefined);
+    assert.strictEqual(cache.peekAttribute(jupiter, 'fake'), undefined);
   });
 
-  test('#retrieveRelatedRecord - existing record + relationship', async function(assert) {
+  test('#peekRelatedRecord - existing record + relationship', async function(assert) {
     const jupiter = await store.addRecord({ type: 'planet', name: 'Jupiter' });
     const callisto = await store.addRecord({ type: 'moon', name: 'Callisto' });
     callisto.set('planet', jupiter);
     await waitForSource(store);
-    assert.strictEqual(
-      cache.retrieveRelatedRecord(callisto, 'planet'),
-      jupiter
-    );
+    assert.strictEqual(cache.peekRelatedRecord(callisto, 'planet'), jupiter);
   });
 
-  test('#retrieveRelatedRecord - missing record', async function(assert) {
+  test('#peekRelatedRecord - missing record', async function(assert) {
     assert.strictEqual(
-      cache.retrieveRelatedRecord({ type: 'planet', id: 'fake' }, 'planet'),
+      cache.peekRelatedRecord({ type: 'planet', id: 'fake' }, 'planet'),
       undefined
     );
   });
 
-  test('#retrieveRelatedRecord - existing record, empty relationship', async function(assert) {
+  test('#peekRelatedRecord - existing record, empty relationship', async function(assert) {
     const callisto = await store.addRecord({
       type: 'moon',
       name: 'Callisto',
       planet: null
     });
-    assert.strictEqual(cache.retrieveRelatedRecord(callisto, 'planet'), null);
+    assert.strictEqual(cache.peekRelatedRecord(callisto, 'planet'), null);
   });
 
-  test('#retrieveRelatedRecord - existing record, missing relationship', async function(assert) {
+  test('#peekRelatedRecord - existing record, missing relationship', async function(assert) {
     const callisto = await store.addRecord({ type: 'moon', name: 'Callisto' });
-    assert.strictEqual(
-      cache.retrieveRelatedRecord(callisto, 'planet'),
-      undefined
-    );
+    assert.strictEqual(cache.peekRelatedRecord(callisto, 'planet'), undefined);
   });
 
-  test('#retrieveRelatedRecords - existing record + relatedRecords', async function(assert) {
+  test('#peekRelatedRecords - existing record + relatedRecords', async function(assert) {
     const callisto = await store.addRecord({ type: 'moon', name: 'Callisto' });
     const europa = await store.addRecord({ type: 'moon', name: 'Europa' });
     const jupiter = await store.addRecord({
@@ -176,42 +170,39 @@ module('Integration - Cache', function(hooks) {
       name: 'Jupiter',
       moons: [callisto, europa]
     });
-    assert.deepEqual(cache.retrieveRelatedRecords(jupiter, 'moons'), [
+    assert.deepEqual(cache.peekRelatedRecords(jupiter, 'moons'), [
       callisto,
       europa
     ]);
   });
 
-  test('#retrieveRelatedRecords - missing record', async function(assert) {
+  test('#peekRelatedRecords - missing record', async function(assert) {
     assert.strictEqual(
-      cache.retrieveRelatedRecords({ type: 'planet', id: 'fake' }, 'moons'),
+      cache.peekRelatedRecords({ type: 'planet', id: 'fake' }, 'moons'),
       undefined
     );
   });
 
-  test('#retrieveRelatedRecords - existing record, empty relationship', async function(assert) {
+  test('#peekRelatedRecords - existing record, empty relationship', async function(assert) {
     const jupiter = await store.addRecord({
       type: 'planet',
       name: 'Jupiter',
       moons: []
     });
-    assert.deepEqual(cache.retrieveRelatedRecords(jupiter, 'moons'), []);
+    assert.deepEqual(cache.peekRelatedRecords(jupiter, 'moons'), []);
   });
 
-  test('#retrieveRelatedRecords - existing record, missing relationship', async function(assert) {
+  test('#peekRelatedRecords - existing record, missing relationship', async function(assert) {
     const jupiter = await store.addRecord({
       type: 'planet',
       name: 'Jupiter'
     });
-    assert.strictEqual(
-      cache.retrieveRelatedRecords(jupiter, 'moons'),
-      undefined
-    );
+    assert.strictEqual(cache.peekRelatedRecords(jupiter, 'moons'), undefined);
   });
 
-  test('#retrieveRecordData - existing record', async function(assert) {
+  test('#peekRecordData - existing record', async function(assert) {
     const jupiter = await store.addRecord({ type: 'planet', name: 'Jupiter' });
-    const retrievedRecordData = cache.retrieveRecordData('planet', jupiter.id);
+    const retrievedRecordData = cache.peekRecordData('planet', jupiter.id);
     assert.ok(retrievedRecordData, 'retrieved record data');
     assert.equal(
       retrievedRecordData.attributes.name,
@@ -220,8 +211,8 @@ module('Integration - Cache', function(hooks) {
     );
   });
 
-  test('#retrieveRecordData - missing record', async function(assert) {
-    assert.strictEqual(cache.retrieveRecordData('planet', 'fake'), undefined);
+  test('peekRecordData - missing record', async function(assert) {
+    assert.strictEqual(cache.peekRecordData('planet', 'fake'), undefined);
   });
 
   test('#query - record', async function(assert) {

--- a/tests/integration/cache-test.js
+++ b/tests/integration/cache-test.js
@@ -104,6 +104,36 @@ module('Integration - Cache', function(hooks) {
     assert.strictEqual(cache.peekRecord('planet', 'fake'), undefined);
   });
 
+  test('#peekRecordByKey - existing record', async function(assert) {
+    const jupiter = await store.addRecord({
+      type: 'planet',
+      name: 'Jupiter',
+      remoteId: 'p01'
+    });
+    assert.strictEqual(
+      cache.peekRecordByKey('planet', 'remoteId', 'p01'),
+      jupiter,
+      'retrieved record'
+    );
+  });
+
+  test('#peekRecordByKey - missing record', async function(assert) {
+    assert.strictEqual(
+      cache.keyMap.keyToId('planet', 'remoteId', 'p01'),
+      undefined,
+      'key is not in map'
+    );
+    assert.strictEqual(
+      cache.peekRecordByKey('planet', 'remoteId', 'p01'),
+      undefined
+    );
+    assert.notStrictEqual(
+      cache.keyMap.keyToId('planet', 'remoteId', 'p01'),
+      undefined,
+      'id has been generated for key'
+    );
+  });
+
   test('#peekRecords', async function(assert) {
     const earth = await store.addRecord({ type: 'planet', name: 'Earth' });
     const jupiter = await store.addRecord({ type: 'planet', name: 'Jupiter' });

--- a/tests/integration/cache-test.js
+++ b/tests/integration/cache-test.js
@@ -231,6 +231,23 @@ module('Integration - Cache', function(hooks) {
     assert.strictEqual(cache.peekRecordData('planet', 'fake'), undefined);
   });
 
+  test('#recordIdFromKey - retrieves a record id based on a known key', async function(assert) {
+    await store.addRecord({
+      type: 'planet',
+      id: '123',
+      name: 'Earth',
+      remoteId: 'p01'
+    });
+    const id = cache.recordIdFromKey('planet', 'remoteId', 'p01');
+    assert.equal(id, '123');
+  });
+
+  test('#recordIdFromKey - generates a record id based on an unknown key', async function(assert) {
+    cache.schema.generateId = () => '123';
+    const id = cache.recordIdFromKey('planet', 'remoteId', 'p01');
+    assert.equal(id, '123');
+  });
+
   test('#query - record', async function(assert) {
     const earth = await store.addRecord({ type: 'planet', name: 'Earth' });
     await store.addRecord({ type: 'planet', name: 'Jupiter' });

--- a/tests/integration/cache-test.js
+++ b/tests/integration/cache-test.js
@@ -99,6 +99,17 @@ module('Integration - Cache', function(hooks) {
     assert.strictEqual(cache.peekRecord('planet', 'fake'), undefined);
   });
 
+  test('#peekRecords', async function(assert) {
+    const earth = await store.addRecord({ type: 'planet', name: 'Earth' });
+    const jupiter = await store.addRecord({ type: 'planet', name: 'Jupiter' });
+    await store.addRecord({ type: 'moon', name: 'Io' });
+
+    const planets = cache.peekRecords('planet');
+    assert.equal(planets.length, 2);
+    assert.ok(planets.includes(earth));
+    assert.ok(planets.includes(jupiter));
+  });
+
   test('#peekKey - existing record + key', async function(assert) {
     const jupiter = await store.addRecord({ type: 'planet', remoteId: '123' });
     assert.equal(cache.peekKey(jupiter, 'remoteId'), '123');

--- a/tests/integration/cache-test.js
+++ b/tests/integration/cache-test.js
@@ -18,6 +18,11 @@ module('Integration - Cache', function(hooks) {
     cache = null;
   });
 
+  test('exposes keyMap and schema', function(assert) {
+    assert.strictEqual(cache.keyMap, store.source.keyMap);
+    assert.strictEqual(cache.schema, store.source.schema);
+  });
+
   test('liveQuery - adds record that becomes a match', async function(assert) {
     const liveQuery = cache.liveQuery(q =>
       q.findRecords('planet').filter({ attribute: 'name', value: 'Jupiter' })

--- a/tests/integration/cache-test.js
+++ b/tests/integration/cache-test.js
@@ -18,9 +18,10 @@ module('Integration - Cache', function(hooks) {
     cache = null;
   });
 
-  test('exposes keyMap and schema', function(assert) {
+  test('exposes properties from underlying MemoryCache', function(assert) {
     assert.strictEqual(cache.keyMap, store.source.keyMap);
     assert.strictEqual(cache.schema, store.source.schema);
+    assert.strictEqual(cache.transformBuilder, store.source.transformBuilder);
   });
 
   test('liveQuery - adds record that becomes a match', async function(assert) {

--- a/tests/integration/store-test.js
+++ b/tests/integration/store-test.js
@@ -15,9 +15,13 @@ module('Integration - Store', function(hooks) {
     store = null;
   });
 
-  test('exposes keyMap and schema', function(assert) {
+  test('exposes properties from source', function(assert) {
     assert.strictEqual(store.keyMap, store.source.keyMap);
     assert.strictEqual(store.schema, store.source.schema);
+    assert.strictEqual(store.transformBuilder, store.transformBuilder);
+    assert.strictEqual(store.transformLog, store.source.transformLog);
+    assert.strictEqual(store.requestQueue, store.source.requestQueue);
+    assert.strictEqual(store.syncQueue, store.source.syncQueue);
   });
 
   test('#addRecord', async function(assert) {
@@ -196,7 +200,7 @@ module('Integration - Store', function(hooks) {
     };
 
     const addRecordATransform = buildTransform(
-      store.source.transformBuilder.addRecord(recordA)
+      store.transformBuilder.addRecord(recordA)
     );
 
     await store.sync(addRecordATransform);
@@ -214,7 +218,7 @@ module('Integration - Store', function(hooks) {
     };
 
     const addRecordATransform = buildTransform(
-      store.source.transformBuilder.addRecord(recordA)
+      store.transformBuilder.addRecord(recordA)
     );
 
     await store.sync(addRecordATransform);
@@ -240,7 +244,7 @@ module('Integration - Store', function(hooks) {
       type: 'planet',
       attributes: { name: 'Pluto' }
     };
-    const tb = store.source.transformBuilder;
+    const tb = store.transformBuilder;
 
     const addRecordATransform = buildTransform(tb.addRecord(recordA));
     const addRecordBTransform = buildTransform(tb.addRecord(recordB));
@@ -273,7 +277,7 @@ module('Integration - Store', function(hooks) {
       type: 'planet',
       attributes: { name: 'Pluto' }
     };
-    const tb = store.source.transformBuilder;
+    const tb = store.transformBuilder;
 
     const addRecordATransform = buildTransform(tb.addRecord(recordA));
     const addRecordBTransform = buildTransform(tb.addRecord(recordB));
@@ -488,7 +492,7 @@ module('Integration - Store', function(hooks) {
       attributes: { name: 'Uranus' }
     };
 
-    const tb = store.source.transformBuilder;
+    const tb = store.transformBuilder;
     const addRecordA = buildTransform(tb.addRecord(recordA));
     const addRecordB = buildTransform(tb.addRecord(recordB));
     const addRecordC = buildTransform(tb.addRecord(recordC));

--- a/tests/integration/store-test.js
+++ b/tests/integration/store-test.js
@@ -15,6 +15,11 @@ module('Integration - Store', function(hooks) {
     store = null;
   });
 
+  test('exposes keyMap and schema', function(assert) {
+    assert.strictEqual(store.keyMap, store.source.keyMap);
+    assert.strictEqual(store.schema, store.source.schema);
+  });
+
   test('#addRecord', async function(assert) {
     const planet = await store.addRecord({ type: 'planet', name: 'Earth' });
 

--- a/tests/integration/store-test.js
+++ b/tests/integration/store-test.js
@@ -80,6 +80,60 @@ module('Integration - Store', function(hooks) {
     }
   });
 
+  test('#peekRecord - existing record', async function(assert) {
+    const jupiter = await store.addRecord({ type: 'planet', name: 'Jupiter' });
+    assert.strictEqual(
+      store.peekRecord('planet', jupiter.id),
+      jupiter,
+      'retrieved record'
+    );
+  });
+
+  test('#peekRecord - missing record', async function(assert) {
+    assert.strictEqual(store.peekRecord('planet', 'fake'), undefined);
+  });
+
+  test('#peekRecordByKey - existing record', async function(assert) {
+    const jupiter = await store.addRecord({
+      type: 'planet',
+      name: 'Jupiter',
+      remoteId: 'p01'
+    });
+    assert.strictEqual(
+      store.peekRecordByKey('planet', 'remoteId', 'p01'),
+      jupiter,
+      'retrieved record'
+    );
+  });
+
+  test('#peekRecordByKey - missing record', async function(assert) {
+    assert.strictEqual(
+      store.keyMap.keyToId('planet', 'remoteId', 'p01'),
+      undefined,
+      'key is not in map'
+    );
+    assert.strictEqual(
+      store.peekRecordByKey('planet', 'remoteId', 'p01'),
+      undefined
+    );
+    assert.notStrictEqual(
+      store.keyMap.keyToId('planet', 'remoteId', 'p01'),
+      undefined,
+      'id has been generated for key'
+    );
+  });
+
+  test('#peekRecords', async function(assert) {
+    const earth = await store.addRecord({ type: 'planet', name: 'Earth' });
+    const jupiter = await store.addRecord({ type: 'planet', name: 'Jupiter' });
+    await store.addRecord({ type: 'moon', name: 'Io' });
+
+    const planets = store.peekRecords('planet');
+    assert.equal(planets.length, 2);
+    assert.ok(planets.includes(earth));
+    assert.ok(planets.includes(jupiter));
+  });
+
   test('#removeRecord - when passed a record, it should serialize its identity in a `removeRecord` op', async function(assert) {
     assert.expect(2);
 


### PR DESCRIPTION
This PR improves typings on the `Store`, exposes several new methods from the underlying `MemorySource` and `MemoryCache`, and refactors some existing methods for consistency.

Specifically, the methods that have been refactored (with deprecations) are:

* `Cache#retrieveRecordData` -> `peekRecordData`
* `Cache#retrieveRecord` -> `peekRecord`
* `Cache#retrieveKey` -> `peekKey`
* `Cache#retrieveAttribute` -> `peekAttribute`
* `Cache#retrieveRelatedRecord` -> `peekRelatedRecord`
* `Cache#retrieveRelatedRecords` -> `peekRelatedRecords`

Methods such as `retrieveRecord` are based on some very early design decisions in ember-orbit, yet no longer have any corollary in either orbit or ember-data. To make ember-orbit feel more familiar to ember-data users, the `retrieveX` methods are being deprecated in favor of `peekX`.

Furthermore, the following methods and properties have been added:

* `Cache#keyMap`
* `Cache#schema`
* `Cache#transformBuilder`
* `Cache#peekRecordByKey`
* `Cache#peekRecords`
* `Cache#recordIdFromKey`
* `Store#keyMap`
* `Store#schema`
* `Store#transformBuilder`
* `Store#peekRecordByKey`
* `Store#rebase`
* `Store#transformsSince`
* `Store#allTransforms`

These methods and properties are almost all proxies to an implementation that exists on an underlying object. The intention is to prevent the need to reference the underlying Orbit objects from the ember-orbit `Store` and `Cache`.
