### PR TITLE
Disable noImplicitAny flag in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "allowJs": true,
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
-    "noImplicitAny": true,
+    "noImplicitAny": false,
     "noImplicitThis": true,
     "alwaysStrict": true,
     "strictNullChecks": true,
@@ -20,28 +20,13 @@
     "baseUrl": ".",
     "module": "es6",
     "paths": {
-      "dummy/tests/*": [
-        "tests/*"
-      ],
-      "dummy/*": [
-        "tests/dummy/app/*",
-        "app/*"
-      ],
-      "ember-orbit": [
-        "addon"
-      ],
-      "ember-orbit/*": [
-        "addon/*"
-      ],
-      "ember-orbit/test-support": [
-        "addon-test-support"
-      ],
-      "ember-orbit/test-support/*": [
-        "addon-test-support/*"
-      ],
-      "*": [
-        "types/*"
-      ]
+      "dummy/tests/*": ["tests/*"],
+      "dummy/*": ["tests/dummy/app/*", "app/*"],
+      "ember-orbit": ["addon"],
+      "ember-orbit/*": ["addon/*"],
+      "ember-orbit/test-support": ["addon-test-support"],
+      "ember-orbit/test-support/*": ["addon-test-support/*"],
+      "*": ["types/*"]
     }
   },
   "include": [


### PR DESCRIPTION
In order to enable the noImplicitAny flag in tsconfig, we'll need to provide proper typings for proxy arrays (and either convert them to TS or ideally replace them with something better).