### PR TITLE
Make strategy name parsing even smarter

### DIFF
--- a/blueprints/data-strategy/files/__root__/__strategies__/__name__.js
+++ b/blueprints/data-strategy/files/__root__/__strategies__/__name__.js
@@ -6,7 +6,6 @@ export default {
     return new LogTruncationStrategy();
   }
 };
-
 <% } else if (type === 'event-logging') { %>
 import { EventLoggingStrategy } from '@orbit/coordinator';
 
@@ -15,7 +14,6 @@ export default {
     return new EventLoggingStrategy();
   }
 };
-
 <% } else if (type === 'sync') { %>
 import { SyncStrategy } from '@orbit/coordinator';
 
@@ -27,7 +25,7 @@ export default {
       /**
        * The name of the source which will have its `transform` event observed.
        */
-      source: 'TODO',
+      source: '<%= source %>',
 
       /**
        * The name of the source which will be acted upon.
@@ -35,7 +33,7 @@ export default {
        * When the source receives the `transform` event, the `sync` method
        * will be invoked on the target.
        */
-      target: 'TODO',
+      target: '<%= target %>',
 
       /**
        * A handler for any errors thrown as a result of invoking `sync` on the
@@ -63,7 +61,6 @@ export default {
     });
   }
 };
-
 <% } else if (type === 'request') { %>
 import { RequestStrategy } from '@orbit/coordinator';
 
@@ -75,18 +72,18 @@ export default {
       /**
        * The name of the source to be observed.
        */
-      source: 'TODO',
+      source: '<%= source %>',
 
       /**
        * The name of the event to observe (e.g. `beforeQuery`, `query`,
        * `beforeUpdate`, `update`, etc.).
        */
-      on: 'TODO',
+      on: '<%= on %>',
 
       /**
        * The name of the source which will be acted upon.
        */
-      target: 'TODO',
+      target: '<%= target %>',
 
       /**
        * The action to perform on the target.
@@ -95,7 +92,7 @@ export default {
        * invoked in the context of this strategy (and thus will have access to
        * both `this.source` and `this.target`).
        */
-      action: 'TODO',
+      action: '<%= action %>',
 
       /**
        * A handler for any errors thrown as a result of performing the action.

--- a/blueprints/data-strategy/index.js
+++ b/blueprints/data-strategy/index.js
@@ -21,6 +21,10 @@ module.exports = {
   locals(options) {
     let { type } = options;
     let name = options.entity.name;
+    let source = 'TODO';
+    let target = 'TODO';
+    let on = 'TODO';
+    let action = 'TODO';
 
     if (type === undefined) {
       if (availableTypes.includes(name)) {
@@ -32,6 +36,22 @@ module.exports = {
       }
     }
 
-    return { type };
+    if (type === 'sync') {
+      let segments = name.split('-');
+      if (segments.length >= 2) {
+        source = segments[0];
+        target = segments[1];
+      }
+    } else if (type === 'request') {
+      let segments = name.split('-');
+      if (segments.length >= 4) {
+        source = segments[0];
+        on = segments[1];
+        target = segments[2];
+        action = segments[3];
+      }
+    }
+
+    return { type, source, target, on, action };
   }
 };


### PR DESCRIPTION
Allow for the following patterns:
* `store-backup-sync` - for a sync strategy
* `store-query-remote-query` - for a request strategy

These patterns will fill out the appropriate `source` and `target` properties for strategies.