### PR TITLE
Refine strategy generator

### DIFF
--- a/blueprints/data-strategy/files/__root__/__strategies__/__name__.js
+++ b/blueprints/data-strategy/files/__root__/__strategies__/__name__.js
@@ -1,25 +1,14 @@
-<% if (type === 'log-truncation') { %>
-import { LogTruncationStrategy } from '@orbit/coordinator';
-
+import { <%= strategyClass %> } from '@orbit/coordinator';
+<% if (type === 'log-truncation' || type === 'event-logging') { %>
 export default {
   create() {
-    return new LogTruncationStrategy();
-  }
-};
-<% } else if (type === 'event-logging') { %>
-import { EventLoggingStrategy } from '@orbit/coordinator';
-
-export default {
-  create() {
-    return new EventLoggingStrategy();
+    return new <%= strategyClass %>();
   }
 };
 <% } else if (type === 'sync') { %>
-import { SyncStrategy } from '@orbit/coordinator';
-
 export default {
   create() {
-    return new SyncStrategy({
+    return new <%= strategyClass %>({
       name: '<%= dasherizedModuleName %>',
 
       /**
@@ -62,11 +51,9 @@ export default {
   }
 };
 <% } else if (type === 'request') { %>
-import { RequestStrategy } from '@orbit/coordinator';
-
 export default {
   create() {
-    return new RequestStrategy({
+    return new <%= strategyClass %>({
       name: '<%= dasherizedModuleName %>',
 
       /**

--- a/blueprints/data-strategy/index.js
+++ b/blueprints/data-strategy/index.js
@@ -25,6 +25,7 @@ module.exports = {
     let target = 'TODO';
     let on = 'TODO';
     let action = 'TODO';
+    let strategyClass;
 
     if (type === undefined) {
       if (availableTypes.includes(name)) {
@@ -37,21 +38,40 @@ module.exports = {
     }
 
     if (type === 'sync') {
+      strategyClass = 'SyncStrategy';
       let segments = name.split('-');
       if (segments.length >= 2) {
         source = segments[0];
         target = segments[1];
       }
     } else if (type === 'request') {
+      strategyClass = 'RequestStrategy';
       let segments = name.split('-');
-      if (segments.length >= 4) {
+      if (segments.length >= 2) {
         source = segments[0];
         on = segments[1];
-        target = segments[2];
-        action = segments[3];
+
+        if (on === on.toLowerCase()) {
+          if (on.indexOf('before') === 0) {
+            on = `before${on.substr(6, 1).toUpperCase()}${on.substr(7)}`;
+          } else if (on.indexOf('fail') === on.length - 4) {
+            on = `${on.substr(0, on.length - 4)}Fail`;
+          }
+        }
+
+        if (segments.length >= 3) {
+          target = segments[2];
+          if (segments.length >= 4) {
+            action = segments[3];
+          }
+        }
       }
+    } else if (type === 'event-logging') {
+      strategyClass = 'EventLoggingStrategy';
+    } else if (type === 'log-truncation') {
+      strategyClass = 'LogTruncationStrategy';
     }
 
-    return { type, source, target, on, action };
+    return { type, strategyClass, source, target, on, action };
   }
 };


### PR DESCRIPTION
* Fixes empty line 1 prior to imports.
* Properly interprets lowercase request strategies such as `store-beforequery-remote-query` and `remote-queryfail` so that the events/actions are properly camelCased.