### PR TITLE
Explicitly declare supported node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "typescript": "^3.7.4"
   },
   "engines": {
-    "npm": ">= 3.0.0"
+    "node": "8.* || 10.* || >= 12.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
This is more of an open question. I guess we should wait for `ember-cli` to drop node 8.