### PR TITLE
Support polymorphic relationships. Issue #257

### DIFF
--- a/addon/-private/fields/has-many.ts
+++ b/addon/-private/fields/has-many.ts
@@ -1,7 +1,7 @@
 import { computed } from '@ember/object';
 import { Dict } from '@orbit/utils';
 
-export default function (type: string, options: Dict<unknown> = {}) {
+export default function (type: string | string[], options: Dict<unknown> = {}) {
   options.kind = 'hasMany';
   options.type = type;
 

--- a/addon/-private/fields/has-one.ts
+++ b/addon/-private/fields/has-one.ts
@@ -1,7 +1,7 @@
 import { computed } from '@ember/object';
 import { Dict } from '@orbit/utils';
 
-export default function (type: string, options: Dict<unknown> = {}) {
+export default function (type: string | string[], options: Dict<unknown> = {}) {
   options.kind = 'hasOne';
   options.type = type;
 

--- a/addon/-private/utils/normalize-record-properties.ts
+++ b/addon/-private/utils/normalize-record-properties.ts
@@ -56,7 +56,7 @@ function assignRelationships(
   const relationships = modelDefinition.relationships || {};
   for (let relationship of Object.keys(relationships)) {
     if (properties[relationship] !== undefined) {
-      let relationshipType = relationships[relationship].type as string;
+      let relationshipType = relationships[relationship].type as string | string[];
       let relationshipProperties = properties[relationship] as
         | RecordIdentity
         | RecordIdentity[]
@@ -73,7 +73,7 @@ function assignRelationships(
 }
 
 function normalizeRelationship(
-  type: string,
+  type: string | string[],
   value: RecordIdentity | RecordIdentity[] | string | string[] | null
 ): RecordRelationship {
   const relationship: RecordRelationship = {};
@@ -82,17 +82,17 @@ function normalizeRelationship(
     relationship.data = [];
     for (let identity of value) {
       if (typeof identity === 'string') {
-        relationship.data.push({ type, id: identity });
+        relationship.data.push({ type: `${type}`, id: identity });
       } else {
-        relationship.data.push({ type, id: identity.id });
+        relationship.data.push({ type: identity.type, id: identity.id });
       }
     }
   } else if (value === null) {
     relationship.data = null;
   } else if (typeof value === 'string') {
-    relationship.data = { type, id: value };
+    relationship.data = { type: `${type}`, id: value };
   } else {
-    relationship.data = { type, id: value.id };
+    relationship.data = { type: value.type, id: value.id };
   }
 
   return relationship;

--- a/addon/-private/utils/normalize-record-properties.ts
+++ b/addon/-private/utils/normalize-record-properties.ts
@@ -56,7 +56,9 @@ function assignRelationships(
   const relationships = modelDefinition.relationships || {};
   for (let relationship of Object.keys(relationships)) {
     if (properties[relationship] !== undefined) {
-      let relationshipType = relationships[relationship].type as string | string[];
+      let relationshipType = relationships[relationship].type as
+        | string
+        | string[];
       let relationshipProperties = properties[relationship] as
         | RecordIdentity
         | RecordIdentity[]

--- a/addon/-private/utils/normalize-record-properties.ts
+++ b/addon/-private/utils/normalize-record-properties.ts
@@ -1,4 +1,4 @@
-import {
+import Orbit, {
   Schema,
   RecordRelationship,
   Record,
@@ -6,6 +6,8 @@ import {
   RecordIdentity
 } from '@orbit/data';
 import { deepSet, Dict } from '@orbit/utils';
+
+const { assert } = Orbit;
 
 export default function normalizeRecordProperties(
   schema: Schema,
@@ -80,11 +82,17 @@ function normalizeRelationship(
 ): RecordRelationship {
   const relationship: RecordRelationship = {};
 
+  const isPolymorphic = Array.isArray(type);
+
   if (isHasMany(value)) {
     relationship.data = [];
     for (let identity of value) {
       if (typeof identity === 'string') {
-        relationship.data.push({ type: `${type}`, id: identity });
+        assert(
+          'The hasMany relationship is polymorphic, so string[] will not work as a value. RecordIdentity[] must be provided for type information.',
+          !isPolymorphic
+        );
+        relationship.data.push({ type: type as string, id: identity });
       } else {
         relationship.data.push({ type: identity.type, id: identity.id });
       }
@@ -92,7 +100,11 @@ function normalizeRelationship(
   } else if (value === null) {
     relationship.data = null;
   } else if (typeof value === 'string') {
-    relationship.data = { type: `${type}`, id: value };
+    assert(
+      'The relationship is polymorphic, so string will not work as a value. RecordIdentity must be provided for type information.',
+      !isPolymorphic
+    );
+    relationship.data = { type: type as string, id: value };
   } else {
     relationship.data = { type: value.type, id: value.id };
   }

--- a/tests/integration/model-test.js
+++ b/tests/integration/model-test.js
@@ -1,5 +1,11 @@
 import EmberObject from '@ember/object';
-import { Planet, Moon, Star } from 'dummy/tests/support/dummy-models';
+import {
+  Planet,
+  Moon,
+  Star,
+  BinaryStar,
+  PlanetarySystem
+} from 'dummy/tests/support/dummy-models';
 import { createStore } from 'dummy/tests/support/store';
 import { module, test } from 'qunit';
 import { getOwner } from '@ember/application';
@@ -9,7 +15,13 @@ module('Integration - Model', function (hooks) {
   let store;
 
   hooks.beforeEach(function () {
-    const models = { planet: Planet, moon: Moon, star: Star };
+    const models = {
+      planet: Planet,
+      moon: Moon,
+      star: Star,
+      binaryStar: BinaryStar,
+      planetarySystem: PlanetarySystem
+    };
     store = createStore({ models });
   });
 
@@ -110,6 +122,21 @@ module('Integration - Model', function (hooks) {
     assert.equal(callisto.planet, jupiter, 'updated inverse');
   });
 
+  test('add to polymorphic hasMany', async function (assert) {
+    const solarSystem = await store.addRecord({
+      type: 'planetarySystem',
+      name: 'Home'
+    });
+    const callisto = await store.addRecord({ type: 'moon', name: 'Callisto' });
+
+    await solarSystem.bodies.pushObject(callisto);
+
+    assert.ok(
+      solarSystem.bodies.includes(callisto),
+      'added record to polymorphic hasMany'
+    );
+  });
+
   test('remove from hasMany', async function (assert) {
     const jupiter = await store.addRecord({ type: 'planet', name: 'Jupiter' });
     const callisto = await store.addRecord({ type: 'moon', name: 'Callisto' });
@@ -119,6 +146,22 @@ module('Integration - Model', function (hooks) {
 
     assert.ok(!jupiter.moons.includes(callisto), 'removed record from hasMany');
     assert.ok(!callisto.planet, 'updated inverse');
+  });
+
+  test('remove from polymorphic hasMany', async function (assert) {
+    const solarSystem = await store.addRecord({
+      type: 'planetarySystem',
+      name: 'Home'
+    });
+    const callisto = await store.addRecord({ type: 'moon', name: 'Callisto' });
+
+    await solarSystem.bodies.pushObject(callisto);
+    await solarSystem.bodies.removeObject(callisto);
+
+    assert.ok(
+      !solarSystem.bodies.includes(callisto),
+      'removed record to polymorphic hasMany'
+    );
   });
 
   test('update via store: replaceRelatedRecords operation invalidates a relationship on model', async function (assert) {
@@ -136,6 +179,24 @@ module('Integration - Model', function (hooks) {
     );
   });
 
+  test('update via store: replaceRelatedRecords operation invalidates a polymorphic relationship on model', async function (assert) {
+    const solarSystem = await store.addRecord({
+      type: 'planetarySystem',
+      name: 'Home'
+    });
+    const callisto = await store.addRecord({ type: 'moon', name: 'Callisto' });
+
+    assert.deepEqual([...solarSystem.bodies], []); // cache the relationship
+    await store.source.update((t) =>
+      t.replaceRelatedRecords(solarSystem, 'bodies', [callisto])
+    );
+    assert.deepEqual(
+      [...solarSystem.bodies],
+      [callisto],
+      'invalidates the relationship'
+    );
+  });
+
   test('replace hasOne with record', async function (assert) {
     const jupiter = await store.addRecord({ type: 'planet', name: 'Jupiter' });
     const callisto = await store.addRecord({ type: 'moon', name: 'Callisto' });
@@ -147,6 +208,36 @@ module('Integration - Model', function (hooks) {
     assert.ok(jupiter.moons.includes(callisto), 'updated inverse');
   });
 
+  test('replace polymorphic hasOne with record', async function (assert) {
+    const solarSystem = await store.addRecord({
+      type: 'planetarySystem',
+      name: 'Home'
+    });
+    const sun = await store.addRecord({ type: 'star', name: 'Sun' });
+    const twinSun = await store.addRecord({
+      type: 'binaryStar',
+      name: 'Twin Sun'
+    });
+
+    solarSystem.set('star', twinSun);
+    await waitForSource(store);
+
+    assert.equal(
+      solarSystem.star,
+      twinSun,
+      'replaced polymorphic hasOne with record'
+    );
+
+    solarSystem.set('star', sun);
+    await waitForSource(store);
+
+    assert.equal(
+      solarSystem.star,
+      sun,
+      'replaced polymorphic hasOne with record of another valid type'
+    );
+  });
+
   test('update via store: replaceRelatedRecord operation invalidates a relationship on model', async function (assert) {
     const jupiter = await store.addRecord({ type: 'planet', name: 'Jupiter' });
     const sun = await store.addRecord({ type: 'star', name: 'Sun' });
@@ -156,6 +247,20 @@ module('Integration - Model', function (hooks) {
       t.replaceRelatedRecord(jupiter, 'sun', sun)
     );
     assert.equal(jupiter.sun, sun, 'invalidates the relationship');
+  });
+
+  test('update via store: replaceRelatedRecord operation invalidates a polymorphic relationship on model', async function (assert) {
+    const solarSystem = await store.addRecord({
+      type: 'planetarySystem',
+      name: 'Home'
+    });
+    const sun = await store.addRecord({ type: 'star', name: 'Sun' });
+
+    assert.equal(solarSystem.star, null); // cache the relationship
+    await store.source.update((t) =>
+      t.replaceRelatedRecord(solarSystem, 'star', sun)
+    );
+    assert.equal(solarSystem.star, sun, 'invalidates the relationship');
   });
 
   test('replace hasOne with null', async function (assert) {
@@ -330,6 +435,31 @@ module('Integration - Model', function (hooks) {
     assert.deepEqual(jupiter.getRelatedRecords('moons').content, [europa, io]);
   });
 
+  test('#addToRelatedRecords (polymorphic)', async function (assert) {
+    const solarSystem = await store.addRecord({
+      type: 'planetarySystem',
+      name: 'Home'
+    });
+    const earth = await store.addRecord({ type: 'planet', name: 'Earth' });
+    const luna = await store.addRecord({ type: 'moon', name: 'Luna' });
+
+    assert.deepEqual(
+      solarSystem.getRelatedRecords('bodies').content,
+      undefined
+    );
+
+    await solarSystem.addToRelatedRecords('bodies', earth);
+
+    assert.deepEqual(solarSystem.getRelatedRecords('bodies').content, [earth]);
+
+    await solarSystem.addToRelatedRecords('bodies', luna);
+
+    assert.deepEqual(solarSystem.getRelatedRecords('bodies').content, [
+      earth,
+      luna
+    ]);
+  });
+
   test('#removeFromRelatedRecords', async function (assert) {
     const europa = await store.addRecord({ type: 'moon', name: 'Europa' });
     const io = await store.addRecord({ type: 'moon', name: 'Io' });
@@ -348,6 +478,29 @@ module('Integration - Model', function (hooks) {
     await jupiter.removeFromRelatedRecords('moons', io);
 
     assert.deepEqual(jupiter.getRelatedRecords('moons').content, []);
+  });
+
+  test('#removeFromRelatedRecords (polymorphic)', async function (assert) {
+    const earth = await store.addRecord({ type: 'planet', name: 'Earth' });
+    const luna = await store.addRecord({ type: 'moon', name: 'Luna' });
+    const solarSystem = await store.addRecord({
+      type: 'planetarySystem',
+      name: 'Home',
+      bodies: [earth, luna]
+    });
+
+    assert.deepEqual(solarSystem.getRelatedRecords('bodies').content, [
+      earth,
+      luna
+    ]);
+
+    await solarSystem.removeFromRelatedRecords('bodies', earth);
+
+    assert.deepEqual(solarSystem.getRelatedRecords('bodies').content, [luna]);
+
+    await solarSystem.removeFromRelatedRecords('bodies', luna);
+
+    assert.deepEqual(solarSystem.getRelatedRecords('bodies').content, []);
   });
 
   test('#update - updates attribute and relationships (with records)', async function (assert) {

--- a/tests/integration/normalize-record-properties-test.js
+++ b/tests/integration/normalize-record-properties-test.js
@@ -138,4 +138,42 @@ module('Integration - normalizeRecordProperties', function (hooks) {
       'normalized hasMany'
     );
   });
+
+  test('#normalizeRecordProperties - polymorphic relationships require RecordIdentity values', async function (assert) {
+    const luna = await store.addRecord({
+      type: 'moon',
+      id: 'luna',
+      name: 'Luna'
+    });
+    const earth = await store.addRecord({
+      type: 'planet',
+      id: 'earth',
+      name: 'Earth'
+    });
+    const sun = await store.addRecord({
+      type: 'star',
+      id: 'sun',
+      name: 'The Sun'
+    });
+
+    assert.throws(
+      () =>
+        normalizeRecordProperties(store.source.schema, {
+          type: 'planetarySystem',
+          id: 'homeSystem',
+          star: sun.id
+        }),
+      'polymorphic hasOne requires RecordIdentity'
+    );
+
+    assert.throws(
+      () =>
+        normalizeRecordProperties(store.source.schema, {
+          type: 'planetarySystem',
+          id: 'homeSystem',
+          bodies: [luna.id, earth.id]
+        }),
+      'polymorphic haMany requires RecordIdentity[]'
+    );
+  });
 });

--- a/tests/integration/normalize-record-properties-test.js
+++ b/tests/integration/normalize-record-properties-test.js
@@ -1,4 +1,10 @@
-import { Planet, Moon, Star } from 'dummy/tests/support/dummy-models';
+import {
+  Planet,
+  Moon,
+  Star,
+  BinaryStar,
+  PlanetarySystem
+} from 'dummy/tests/support/dummy-models';
 import { createStore } from 'dummy/tests/support/store';
 import { module, test } from 'qunit';
 
@@ -6,7 +12,13 @@ import normalizeRecordProperties from 'ember-orbit/-private/utils/normalize-reco
 
 module('Integration - normalizeRecordProperties', function (hooks) {
   let store;
-  const models = { planet: Planet, moon: Moon, star: Star };
+  const models = {
+    planet: Planet,
+    moon: Moon,
+    star: Star,
+    binaryStar: BinaryStar,
+    planetarySystem: PlanetarySystem
+  };
 
   hooks.beforeEach(function () {
     store = createStore({ models });
@@ -77,6 +89,53 @@ module('Integration - normalizeRecordProperties', function (hooks) {
       normalized.relationships.sun,
       { data: null },
       'normalized nullable hasOne'
+    );
+  });
+
+  test('#normalizeRecordProperties - polymorphic relationships', async function (assert) {
+    const luna = await store.addRecord({
+      type: 'moon',
+      id: 'luna',
+      name: 'Luna'
+    });
+    const earth = await store.addRecord({
+      type: 'planet',
+      id: 'earth',
+      name: 'Earth'
+    });
+    const sun = await store.addRecord({
+      type: 'star',
+      id: 'sun',
+      name: 'The Sun'
+    });
+
+    const expectedName = 'Our Solar System';
+    const normalized = normalizeRecordProperties(store.source.schema, {
+      type: 'planetarySystem',
+      id: 'homeSystem',
+      name: expectedName,
+      star: sun,
+      bodies: [luna, earth]
+    });
+
+    assert.equal(normalized.id, 'homeSystem', 'normalized id');
+    assert.equal(normalized.type, 'planetarySystem', 'normalized type');
+    assert.deepEqual(normalized.keys, undefined, 'normalized keys');
+    assert.deepEqual(normalized.attributes, { name: expectedName });
+    assert.deepEqual(
+      normalized.relationships.star,
+      { data: { type: 'star', id: 'sun' } },
+      'normalized hasOne'
+    );
+    assert.deepEqual(
+      normalized.relationships.bodies,
+      {
+        data: [
+          { type: 'moon', id: 'luna' },
+          { type: 'planet', id: 'earth' }
+        ]
+      },
+      'normalized hasMany'
     );
   });
 });

--- a/tests/integration/store-test.js
+++ b/tests/integration/store-test.js
@@ -1,11 +1,23 @@
-import { Planet, Moon, Star } from 'dummy/tests/support/dummy-models';
+import {
+  Planet,
+  Moon,
+  Star,
+  BinaryStar,
+  PlanetarySystem
+} from 'dummy/tests/support/dummy-models';
 import { createStore } from 'dummy/tests/support/store';
 import { buildTransform } from '@orbit/data';
 import { module, test } from 'qunit';
 
 module('Integration - Store', function (hooks) {
   let store;
-  const models = { planet: Planet, moon: Moon, star: Star };
+  const models = {
+    planet: Planet,
+    moon: Moon,
+    star: Star,
+    binaryStar: BinaryStar,
+    planetarySystem: PlanetarySystem
+  };
 
   hooks.beforeEach(function () {
     store = createStore({ models });

--- a/tests/support/dummy-models.js
+++ b/tests/support/dummy-models.js
@@ -19,3 +19,16 @@ export const Star = Model.extend({
   planets: hasMany('planet'),
   isStable: attr('boolean')
 });
+
+export const BinaryStar = Model.extend({
+  name: attr('string'),
+  starOne: hasOne('star'),
+  starTwo: hasOne('star')
+});
+
+// Example for Polymorphism
+export const PlanetarySystem = Model.extend({
+  name: attr('string'),
+  star: hasOne(['binaryStar', 'star']),
+  bodies: hasMany(['planet', 'moon'])
+});

--- a/tests/unit/model-test.ts
+++ b/tests/unit/model-test.ts
@@ -2,7 +2,7 @@ import { key, attr, hasOne, hasMany, Model } from 'ember-orbit';
 import { module, test } from 'qunit';
 
 module('Unit - Model', function (hooks) {
-  let Planet: any, Moon: any, Star: any;
+  let Planet: any, Moon: any, Star: any, SolarSystem: any;
 
   hooks.beforeEach(function () {
     Planet = Model.extend({
@@ -21,12 +21,17 @@ module('Unit - Model', function (hooks) {
       name: attr('string'),
       planets: hasMany('planet')
     });
+
+    SolarSystem = Model.extend({
+      bodies: hasMany(['star', 'planet', 'moon'])
+    });
   });
 
   hooks.afterEach(function () {
     Planet = null;
     Moon = null;
     Star = null;
+    SolarSystem = null;
   });
 
   test('it exists', function (assert) {
@@ -82,5 +87,10 @@ module('Unit - Model', function (hooks) {
     keys = Object.keys(relationships);
     assert.equal(keys.length, 1);
     assert.equal(keys[0], 'planets');
+
+    relationships = SolarSystem.relationships;
+    keys = Object.keys(relationships);
+    assert.equal(keys.length, 1);
+    assert.deepEqual(keys[0], 'bodies');
   });
 });


### PR DESCRIPTION
Allow string OR array of string types for hasMany and hasOne, just as Orbit.js accepts the same for relationship types.