### PR TITLE
Fix decorators for use in typescript

### DIFF
--- a/addon/-private/fields/attr.ts
+++ b/addon/-private/fields/attr.ts
@@ -1,11 +1,16 @@
 import { tracked } from '@glimmer/tracking';
-import { Dict } from '@orbit/utils';
+import { AttributeDefinition } from '@orbit/data';
 
 import Model from '../model';
 
-export default function attr(type: string, options: Dict<unknown> = {}) {
-  function trackedAttr(target: any, key: string, desc: PropertyDescriptor) {
-    let trackedDesc = tracked(target, key, desc);
+export default function attr(target: Model, key: string);
+export default function attr(type?: string, options?: AttributeDefinition);
+export default function attr(
+  type?: Model | string,
+  options: string | AttributeDefinition = {}
+) {
+  function trackedAttr(target: any, key: string, desc?: PropertyDescriptor) {
+    let trackedDesc = tracked(target, key, desc as PropertyDescriptor);
     let { get: originalGet, set: originalSet } = trackedDesc;
 
     let defaultAssigned = new WeakSet();
@@ -52,11 +57,11 @@ export default function attr(type: string, options: Dict<unknown> = {}) {
     return trackedDesc;
   }
 
-  if (arguments.length === 3) {
+  if (typeof options === 'string') {
     options = {};
     return trackedAttr.apply(null, arguments);
   }
 
-  options.type = type;
+  options.type = type as string;
   return trackedAttr;
 }

--- a/addon/-private/fields/key.ts
+++ b/addon/-private/fields/key.ts
@@ -1,9 +1,11 @@
 import { tracked } from '@glimmer/tracking';
-import { Dict } from '@orbit/utils';
+import { KeyDefinition } from '@orbit/data';
 
 import Model from '../model';
 
-export default function key(options: Dict<unknown> = {}) {
+export default function key(target: Model, key: string);
+export default function key(options?: KeyDefinition);
+export default function key(options: Model | KeyDefinition = {}, _?: unknown) {
   function trackedKey(target: any, key: string, desc: PropertyDescriptor) {
     let trackedDesc = tracked(target, key, desc);
     let { get: originalGet, set: originalSet } = trackedDesc;


### PR DESCRIPTION
This enables all possible forms:

```ts
class Planet extends Model {
  @key remoteId: string;
  @key() remoteId: string;
  @key({}) remoteId: string;

  @attr name: string;
  @attr() name: string;
  @attr('string') name: string;
  @attr('string', {}) name: string;
}
```

The other option is to require in TypeScript to use `@attr() and @key()`. In JavaScript both `@attr` and `@attr()` will work.

What do you think @dgeb ?