### PR TITLE
Make records on non forked stores readonly

### DIFF
--- a/addon/initializers/ember-orbit-config.ts
+++ b/addon/initializers/ember-orbit-config.ts
@@ -25,6 +25,7 @@ export interface OrbitConfig {
   skipCoordinatorService: boolean;
   skipSchemaService: boolean;
   skipKeyMapService: boolean;
+  mutableModels: boolean;
 }
 
 export const DEFAULT_ORBIT_CONFIG: OrbitConfig = {
@@ -50,7 +51,8 @@ export const DEFAULT_ORBIT_CONFIG: OrbitConfig = {
   skipStoreInjections: false,
   skipCoordinatorService: false,
   skipSchemaService: false,
-  skipKeyMapService: false
+  skipKeyMapService: false,
+  mutableModels: false
 };
 
 interface ApplicationRegistry {

--- a/addon/initializers/ember-orbit-services.ts
+++ b/addon/initializers/ember-orbit-services.ts
@@ -53,6 +53,12 @@ export function initialize(application: Application) {
   if (!orbitConfig.skipStoreService) {
     application.register(`service:${orbitConfig.services.store}`, Store);
 
+    application.register(
+      'ember-orbit:configMutableModels',
+      orbitConfig.mutableModels,
+      { instantiate: false }
+    );
+
     // Store source (which is injected in store service)
     application.register(
       `${orbitConfig.types.source}:store`,
@@ -62,6 +68,11 @@ export function initialize(application: Application) {
       `service:${orbitConfig.services.store}`,
       'source',
       `${orbitConfig.types.source}:store`
+    );
+    application.inject(
+      `service:${orbitConfig.services.store}`,
+      'mutableModels',
+      'ember-orbit:configMutableModels'
     );
 
     if (!orbitConfig.skipStoreInjections) {

--- a/tests/integration/cache-test.js
+++ b/tests/integration/cache-test.js
@@ -9,7 +9,7 @@ module('Integration - Cache', function (hooks) {
 
   hooks.beforeEach(function () {
     const models = { planet: Planet, moon: Moon, star: Star };
-    store = createStore({ models });
+    store = createStore({ models }).fork();
     cache = store.cache;
   });
 

--- a/tests/integration/model-test.js
+++ b/tests/integration/model-test.js
@@ -22,7 +22,7 @@ module('Integration - Model', function (hooks) {
       binaryStar: BinaryStar,
       planetarySystem: PlanetarySystem
     };
-    store = createStore({ models });
+    store = createStore({ models }).fork();
   });
 
   hooks.afterEach(function () {

--- a/tests/integration/rendering-test.js
+++ b/tests/integration/rendering-test.js
@@ -14,7 +14,7 @@ module('Rendering', function (hooks) {
 
   hooks.beforeEach(function () {
     const models = { planet: Planet, moon: Moon };
-    store = createStore({ models });
+    store = createStore({ models }).fork();
     cache = store.cache;
   });
 


### PR DESCRIPTION
I see how we might want a setting to disable the new behaviour. But I am not sure where it would live. Maybe in env with other ember-orbit config? What do you think @dgeb?