### PR TITLE
disable deprecations during tests

### DIFF
--- a/tests/support/store.js
+++ b/tests/support/store.js
@@ -1,7 +1,14 @@
 import Ember from 'ember';
 import { initialize as initializeConfig } from 'ember-orbit/initializers/ember-orbit-config';
 import { initialize as initializeServices } from 'ember-orbit/initializers/ember-orbit-services';
+import { registerDeprecationHandler } from '@ember/debug';
 import Owner from './owner';
+
+registerDeprecationHandler((_, options, next) => {
+  if (options.id !== 'meta-destruction-apis') {
+    next();
+  }
+});
 
 export function createOwner() {
   const registry = new Ember.Registry();


### PR DESCRIPTION
Canary and beta tests are failing because of https://github.com/ember-polyfills/ember-destroyable-polyfill/issues/55
I disabled the deprecation warning in tests for now.
