### PR TITLE
Record accessors

### DIFF
--- a/addon/-private/accessors/index.ts
+++ b/addon/-private/accessors/index.ts
@@ -1,2 +1,4 @@
 export { RecordAccessor } from './record-accessor';
+export { RecordsMutableAccessor as RecordsAccessor } from './records-accessor';
 export { RelatedRecordAccessor } from './related-record-accessor';
+export { RelatedRecordsMutableAccessor as RelatedRecordsAccessor } from './related-records-accessor';

--- a/addon/-private/accessors/index.ts
+++ b/addon/-private/accessors/index.ts
@@ -1,0 +1,2 @@
+export { RecordAccessor } from './record-accessor';
+export { RelatedRecordAccessor } from './related-record-accessor';

--- a/addon/-private/accessors/record-accessor.ts
+++ b/addon/-private/accessors/record-accessor.ts
@@ -1,0 +1,80 @@
+import {
+  RecordIdentity,
+  RequestOptions,
+  Record,
+  cloneRecordIdentity,
+  FindRecordTerm
+} from '@orbit/data';
+import { Dict } from '@orbit/utils';
+
+import Store from '../store';
+import Model from '../model';
+import normalizeRecordProperties from '../utils/normalize-record-properties';
+
+export class RecordAccessor<T extends Model = Model> extends FindRecordTerm {
+  #store: Store;
+
+  constructor(store: Store, identity: RecordIdentity) {
+    super(cloneRecordIdentity(identity));
+    this.#store = store;
+  }
+
+  async update(
+    properties: Dict<unknown> = {},
+    options?: RequestOptions
+  ): Promise<T> {
+    const { record: identity } = this.expression;
+    const record = normalizeRecordProperties(this.#store.source.schema, {
+      ...properties,
+      ...identity
+    });
+    if (record.attributes && !record.relationships && !record.keys) {
+      const attributeNames = Object.keys(record.attributes);
+      await this.#store.update(
+        (t) =>
+          attributeNames.map((attribute) =>
+            t.replaceAttribute(identity, attribute, properties[attribute])
+          ),
+        options
+      );
+    } else {
+      await this.#store.update((t) => t.updateRecord(record), options);
+    }
+
+    return this.peek() as T;
+  }
+
+  /**
+   * Removes a record from the store
+   * @method remove
+   * @param {object} options
+   */
+  async remove(options?: RequestOptions): Promise<void> {
+    const { record: identity } = this.expression;
+    await this.#store.update((t) => t.removeRecord(identity), options);
+  }
+
+  unload(): void {
+    const { record: identity } = this.expression;
+    this.#store.cache.unload(identity);
+  }
+
+  raw(): Record | undefined {
+    const { record: identity } = this.expression;
+    return this.#store.source.cache.getRecordSync(identity);
+  }
+
+  peek(): T | undefined {
+    const record = this.raw();
+
+    if (record) {
+      return this.#store.cache.lookup(record) as T;
+    }
+
+    return undefined;
+  }
+
+  query(options?: RequestOptions): Promise<T> {
+    return this.#store.query(this.toQueryExpression(), options) as Promise<T>;
+  }
+}

--- a/addon/-private/accessors/records-accessor.ts
+++ b/addon/-private/accessors/records-accessor.ts
@@ -1,0 +1,82 @@
+import {
+  Record,
+  RequestOptions,
+  buildQuery,
+  FindRecordsTerm
+} from '@orbit/data';
+import { Dict } from '@orbit/utils';
+
+import Store from '../store';
+import Model from '../model';
+import normalizeRecordProperties from '../utils/normalize-record-properties';
+import LiveQuery from '../live-query';
+
+export class RecordsAccessor<T extends Model = Model> extends FindRecordsTerm {
+  #store: Store;
+
+  constructor(store: Store, type: string) {
+    super(type);
+    this.#store = store;
+  }
+
+  query(options?: RequestOptions): Promise<T[]> {
+    return this.#store.query(this.toQueryExpression(), options) as Promise<T[]>;
+  }
+
+  raw(): Record[] | undefined {
+    return this.#store.source.cache.query(this.toQueryExpression()) as Record[];
+  }
+
+  live(options?: RequestOptions): LiveQuery {
+    const query = buildQuery(this.toQueryExpression(), options);
+    const liveQuery = this.#store.source.cache.liveQuery(query);
+
+    return new LiveQuery({ liveQuery, cache: this.#store.cache, query });
+  }
+}
+
+export class RecordsMutableAccessor<
+  T extends Model = Model
+> extends RecordsAccessor<T> {
+  #store: Store;
+
+  constructor(store: Store, type: string) {
+    super(store, type);
+    this.#store = store;
+  }
+
+  raw(): Record[] | undefined {
+    const { type } = this.expression;
+    return this.#store.source.cache.getRecordsSync(type);
+  }
+
+  peek(): T[] | undefined {
+    const records = this.raw();
+
+    if (records) {
+      return this.#store.cache.lookup(records) as T[];
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Adds a record of a given type to the store
+   * @method add
+   * @param {object} properties
+   * @param {object} options
+   */
+  async add(
+    properties: Dict<unknown> = {},
+    options?: RequestOptions
+  ): Promise<T> {
+    const { type } = this.expression;
+    const record = normalizeRecordProperties(this.#store.source.schema, {
+      ...properties,
+      type
+    });
+    await this.#store.update((t) => t.addRecord(record), options);
+
+    return this.#store.record(record).peek() as T;
+  }
+}

--- a/addon/-private/accessors/records-accessor.ts
+++ b/addon/-private/accessors/records-accessor.ts
@@ -27,7 +27,7 @@ export class RecordsAccessor<T extends Model = Model> extends FindRecordsTerm {
     return this.#store.source.cache.query(this.toQueryExpression()) as Record[];
   }
 
-  live(options?: RequestOptions): LiveQuery {
+  live(options?: RequestOptions): LiveQuery<T> {
     const query = buildQuery(this.toQueryExpression(), options);
     const liveQuery = this.#store.source.cache.liveQuery(query);
 

--- a/addon/-private/accessors/related-record-accessor.ts
+++ b/addon/-private/accessors/related-record-accessor.ts
@@ -1,0 +1,59 @@
+import {
+  Record,
+  RecordIdentity,
+  RequestOptions,
+  cloneRecordIdentity,
+  FindRelatedRecordTerm
+} from '@orbit/data';
+
+import Store from '../store';
+import Model from '../model';
+
+export class RelatedRecordAccessor<
+  T extends Model = Model
+> extends FindRelatedRecordTerm {
+  #store: Store;
+
+  constructor(store: Store, identity: RecordIdentity, relationship: string) {
+    super(cloneRecordIdentity(identity), relationship);
+    this.#store = store;
+  }
+
+  async replace(record: T | null, options?: RequestOptions): Promise<void> {
+    const { record: identity, relationship } = this.expression;
+    await this.#store.update(
+      (t) =>
+        t.replaceRelatedRecord(
+          identity,
+          relationship,
+          record ? cloneRecordIdentity(record) : null
+        ),
+      options
+    );
+  }
+
+  raw(): Record | null | undefined {
+    const { record: identity, relationship } = this.expression;
+    return this.#store.source.cache.getRelatedRecordSync(
+      identity,
+      relationship
+    );
+  }
+
+  peek(): T | null | undefined {
+    const record = this.raw();
+
+    if (record) {
+      return this.#store.cache.lookup(record) as T | null;
+    }
+
+    return record;
+  }
+
+  query(options?: RequestOptions): Promise<T | null> {
+    return this.#store.query(
+      this.toQueryExpression(),
+      options
+    ) as Promise<T | null>;
+  }
+}

--- a/addon/-private/accessors/related-records-accessor.ts
+++ b/addon/-private/accessors/related-records-accessor.ts
@@ -1,0 +1,112 @@
+import {
+  Record,
+  RequestOptions,
+  RecordIdentity,
+  cloneRecordIdentity,
+  buildQuery,
+  FindRelatedRecordsTerm
+} from '@orbit/data';
+
+import Store from '../store';
+import Model from '../model';
+import LiveQuery from '../live-query';
+
+export class RelatedRecordsAccessor<
+  T extends Model = Model
+> extends FindRelatedRecordsTerm {
+  #store: Store;
+
+  constructor(store: Store, identity: RecordIdentity, relationship: string) {
+    super(cloneRecordIdentity(identity), relationship);
+    this.#store = store;
+  }
+
+  query(options?: RequestOptions): Promise<T[]> {
+    return this.#store.query(this.toQueryExpression(), options) as Promise<T[]>;
+  }
+
+  raw(): Record[] | undefined {
+    return this.#store.source.cache.query(this.toQueryExpression()) as Record[];
+  }
+
+  live(options?: RequestOptions): LiveQuery {
+    const query = buildQuery(this.toQueryExpression(), options);
+    const liveQuery = this.#store.source.cache.liveQuery(query);
+
+    return new LiveQuery({ liveQuery, cache: this.#store.cache, query });
+  }
+}
+
+export class RelatedRecordsMutableAccessor<
+  T extends Model = Model
+> extends RelatedRecordsAccessor<T> {
+  #store: Store;
+
+  constructor(store: Store, identity: RecordIdentity, relationship: string) {
+    super(store, identity, relationship);
+    this.#store = store;
+  }
+
+  raw(): Record[] | undefined {
+    const { record: identity, relationship } = this.expression;
+    return this.#store.source.cache.getRelatedRecordsSync(
+      identity,
+      relationship
+    );
+  }
+
+  peek(): T[] | undefined {
+    const records = this.raw();
+
+    if (records) {
+      return this.#store.cache.lookup(records) as T[];
+    }
+
+    return undefined;
+  }
+
+  async add(record: RecordIdentity, options?: RequestOptions): Promise<void> {
+    const { record: identity, relationship } = this.expression;
+    await this.#store.update(
+      (t) =>
+        t.addToRelatedRecords(
+          identity,
+          relationship,
+          cloneRecordIdentity(record)
+        ),
+      options
+    );
+  }
+
+  async remove(
+    record: RecordIdentity,
+    options?: RequestOptions
+  ): Promise<void> {
+    const { record: identity, relationship } = this.expression;
+    await this.#store.update(
+      (t) =>
+        t.removeFromRelatedRecords(
+          identity,
+          relationship,
+          cloneRecordIdentity(record)
+        ),
+      options
+    );
+  }
+
+  async replace(
+    records: RecordIdentity[],
+    options?: RequestOptions
+  ): Promise<void> {
+    const { record: identity, relationship } = this.expression;
+    await this.#store.update(
+      (t) =>
+        t.replaceRelatedRecords(
+          identity,
+          relationship,
+          records.map((record) => cloneRecordIdentity(record))
+        ),
+      options
+    );
+  }
+}

--- a/addon/-private/accessors/related-records-accessor.ts
+++ b/addon/-private/accessors/related-records-accessor.ts
@@ -29,7 +29,7 @@ export class RelatedRecordsAccessor<
     return this.#store.source.cache.query(this.toQueryExpression()) as Record[];
   }
 
-  live(options?: RequestOptions): LiveQuery {
+  live(options?: RequestOptions): LiveQuery<T> {
     const query = buildQuery(this.toQueryExpression(), options);
     const liveQuery = this.#store.source.cache.liveQuery(query);
 

--- a/addon/-private/cache.ts
+++ b/addon/-private/cache.ts
@@ -62,14 +62,23 @@ export default class Cache {
     return this._sourceCache.transformBuilder;
   }
 
+  /**
+   * @deprecated
+   */
   peekRecordData(type: string, id: string): Record | undefined {
     return this._sourceCache.getRecordSync({ type, id });
   }
 
+  /**
+   * @deprecated
+   */
   includesRecord(type: string, id: string): boolean {
     return !!this.peekRecordData(type, id);
   }
 
+  /**
+   * @deprecated
+   */
   peekRecord(type: string, id: string): Model | undefined {
     if (this.includesRecord(type, id)) {
       return this.lookup({ type, id }) as Model;
@@ -77,6 +86,9 @@ export default class Cache {
     return undefined;
   }
 
+  /**
+   * @deprecated
+   */
   peekRecords(type: string): Model[] {
     const identities = this._sourceCache.getRecordsSync(type);
     return this.lookup(identities) as Model[];
@@ -114,6 +126,9 @@ export default class Cache {
     return record && deepGet(record, ['attributes', attribute]);
   }
 
+  /**
+   * @deprecated
+   */
   peekRelatedRecord(
     identity: RecordIdentity,
     relationship: string
@@ -129,6 +144,9 @@ export default class Cache {
     }
   }
 
+  /**
+   * @deprecated
+   */
   peekRelatedRecords(
     identity: RecordIdentity,
     relationship: string
@@ -178,6 +196,9 @@ export default class Cache {
     return new LiveQuery({ liveQuery, cache: this, query });
   }
 
+  /**
+   * @deprecated
+   */
   find(type: string, id?: string): Model | Model[] {
     if (id === undefined) {
       return this.findRecords(type);
@@ -186,10 +207,16 @@ export default class Cache {
     }
   }
 
+  /**
+   * @deprecated
+   */
   findRecord(type: string, id: string, options?: RequestOptions): Model {
     return this.query((q) => q.findRecord({ type, id }), options) as Model;
   }
 
+  /**
+   * @deprecated
+   */
   findRecords(type: string, options?: RequestOptions): Model[] {
     return this.query((q) => q.findRecords(type), options) as Model[];
   }

--- a/addon/-private/cache.ts
+++ b/addon/-private/cache.ts
@@ -162,11 +162,11 @@ export default class Cache {
     }
   }
 
-  query(
+  query<T extends Model = Model>(
     queryOrExpressions: QueryOrExpressions,
     options?: RequestOptions,
     id?: string
-  ): QueryResult {
+  ): QueryResult<T> {
     const query = buildQuery(
       queryOrExpressions,
       options,
@@ -181,11 +181,11 @@ export default class Cache {
     }
   }
 
-  liveQuery(
+  liveQuery<T extends Model = Model>(
     queryOrExpressions: QueryOrExpressions,
     options?: RequestOptions,
     id?: string
-  ): LiveQuery {
+  ): LiveQuery<T> {
     const query = buildQuery(
       queryOrExpressions,
       options,
@@ -229,27 +229,29 @@ export default class Cache {
     }
   }
 
-  lookup(
+  lookup<T extends Model = Model>(
     result: QueryResult<Record>,
     expressions = 1
-  ): Model | Model[] | null | (Model | Model[] | null)[] {
+  ): QueryResult<T> {
     if (isQueryResultData(result, expressions)) {
       return (result as QueryResultData[]).map((result) =>
-        this._lookup(result)
+        this._lookup<T>(result)
       );
     } else {
-      return this._lookup(result);
+      return this._lookup<T>(result);
     }
   }
 
-  private _lookup(result: QueryResultData): Model | Model[] | null {
+  private _lookup<T extends Model = Model>(
+    result: QueryResultData
+  ): T | T[] | null {
     if (Array.isArray(result)) {
-      return result.map((identity) => this._lookup(identity) as Model);
+      return result.map((identity) => this._lookup<T>(identity) as T);
     } else if (result) {
-      let record = this._identityMap.get(result);
+      let record = this._identityMap.get(result) as T;
 
       if (!record) {
-        record = this._modelFactory.create(result);
+        record = this._modelFactory.create(result) as T;
         this._identityMap.set(result, record);
       }
 

--- a/addon/-private/fields/attr.ts
+++ b/addon/-private/fields/attr.ts
@@ -29,7 +29,7 @@ export default function attr(
 
       if (value !== oldValue) {
         this.assertMutableFields();
-        this.replaceAttribute(property, value).catch(() =>
+        this.update({ [property]: value }).catch(() =>
           getCache(this).notifyPropertyChange()
         );
         getCache(this).value = value;

--- a/addon/-private/fields/has-many.ts
+++ b/addon/-private/fields/has-many.ts
@@ -28,7 +28,7 @@ export default function hasMany(
           addLegacyMutationMethods(
             record,
             property,
-            record.getRelatedRecords(property) || []
+            record.relatedRecords(property).peek() || []
           )
         );
         caches.set(record, cache);
@@ -79,17 +79,17 @@ function addLegacyMutationMethods(
     pushObject: {
       value: (record: Model) => {
         deprecate(
-          'pushObject(record) is deprecated. Use record.addToRelatedRecords(relationship, record)'
+          'pushObject(record) is deprecated. Use record.relatedRecords(relationship).add(record)'
         );
-        owner.addToRelatedRecords(relationship, record);
+        owner.relatedRecords(relationship).add(record);
       }
     },
     removeObject: {
       value: (record: Model) => {
         deprecate(
-          'removeObject(record) is deprecated. Use record.removeFromRelatedRecords(relationship, record)'
+          'removeObject(record) is deprecated. Use record.relatedRecords(relationship).remove(record)'
         );
-        owner.removeFromRelatedRecords(relationship, record);
+        owner.relatedRecords(relationship).remove(record);
       }
     }
   });

--- a/addon/-private/fields/has-one.ts
+++ b/addon/-private/fields/has-one.ts
@@ -16,7 +16,7 @@ export default function hasOne(
     function getCache(record: Model): Cache<Model | null | undefined> {
       let cache = caches.get(record);
       if (!cache) {
-        cache = new Cache(() => record.getRelatedRecord(property));
+        cache = new Cache(() => record.relatedRecord(property).peek());
         caches.set(record, cache);
       }
       return cache;
@@ -27,13 +27,13 @@ export default function hasOne(
     }
 
     function set(this: Model, value: any) {
-      const oldValue = this.getRelatedRecord(property);
+      const oldValue = this.relatedRecord(property).peek();
 
       if (value !== oldValue) {
         this.assertMutableFields();
-        this.replaceRelatedRecord(property, value).catch(() =>
-          getCache(this).notifyPropertyChange()
-        );
+        this.relatedRecord(property)
+          .replace(value)
+          .catch(() => getCache(this).notifyPropertyChange());
       }
     }
 

--- a/addon/-private/live-query.ts
+++ b/addon/-private/live-query.ts
@@ -22,7 +22,7 @@ export interface LiveQuerySettings {
   cache: Cache;
 }
 
-export default class LiveQuery implements Iterable<Model> {
+export default class LiveQuery<T extends Model = Model> implements Iterable<T> {
   #query: Query;
   #cache: Cache;
 
@@ -56,7 +56,7 @@ export default class LiveQuery implements Iterable<Model> {
     associateDestroyableChild(this.#cache, this);
   }
 
-  get value(): QueryResult {
+  get value(): QueryResult<T> {
     return getValue(this.#value);
   }
 
@@ -64,14 +64,14 @@ export default class LiveQuery implements Iterable<Model> {
     return (this.value as Model[]).length;
   }
 
-  [Symbol.iterator](): IterableIterator<Model> {
+  [Symbol.iterator](): IterableIterator<T> {
     assert(
       'LiveQuery result is not a collection. You can access the result as `liveQuery.value`.',
       Array.isArray(this.value)
     );
 
     this.#iteratorAccessed = true;
-    return (this.value as Model[])[Symbol.iterator]();
+    return (this.value as T[])[Symbol.iterator]();
   }
 
   destroy() {

--- a/addon/-private/model.ts
+++ b/addon/-private/model.ts
@@ -16,6 +16,7 @@ import {
 import { DEBUG } from '@glimmer/env';
 
 import Store from './store';
+import { RelatedRecordAccessor } from './accessors';
 
 const { assert } = Orbit;
 
@@ -85,6 +86,10 @@ export default class Model {
       (t) => t.replaceAttribute(this.identity, attribute, value),
       options
     );
+  }
+
+  relatedRecord(relationship: string): RelatedRecordAccessor<Model> {
+    return new RelatedRecordAccessor(this.store, this.identity, relationship);
   }
 
   getRelatedRecord(relationship: string): Model | null | undefined {

--- a/addon/-private/model.ts
+++ b/addon/-private/model.ts
@@ -16,7 +16,7 @@ import {
 import { DEBUG } from '@glimmer/env';
 
 import Store from './store';
-import { RelatedRecordAccessor } from './accessors';
+import { RelatedRecordAccessor, RelatedRecordsAccessor } from './accessors';
 
 const { assert } = Orbit;
 
@@ -90,6 +90,10 @@ export default class Model {
 
   relatedRecord(relationship: string): RelatedRecordAccessor<Model> {
     return new RelatedRecordAccessor(this.store, this.identity, relationship);
+  }
+
+  relatedRecords(relationship: string): RelatedRecordsAccessor<Model> {
+    return new RelatedRecordsAccessor(this.store, this.identity, relationship);
   }
 
   getRelatedRecord(relationship: string): Model | null | undefined {

--- a/addon/-private/store.ts
+++ b/addon/-private/store.ts
@@ -19,6 +19,7 @@ import Cache from './cache';
 import Model, { QueryResult } from './model';
 import ModelFactory from './model-factory';
 import normalizeRecordProperties from './utils/normalize-record-properties';
+import { RecordAccessor } from './accessors';
 
 const { deprecate } = Orbit;
 
@@ -160,6 +161,10 @@ export default class Store {
     );
     const result = await this.source.query(query);
     return this.cache.lookup(result, query.expressions.length);
+  }
+
+  record(identity: RecordIdentity): RecordAccessor {
+    return new RecordAccessor(this, identity);
   }
 
   /**

--- a/addon/-private/store.ts
+++ b/addon/-private/store.ts
@@ -19,7 +19,7 @@ import Cache from './cache';
 import Model, { QueryResult } from './model';
 import ModelFactory from './model-factory';
 import normalizeRecordProperties from './utils/normalize-record-properties';
-import { RecordAccessor } from './accessors';
+import { RecordAccessor, RecordsAccessor } from './accessors';
 
 const { deprecate } = Orbit;
 
@@ -165,6 +165,10 @@ export default class Store {
 
   record(identity: RecordIdentity): RecordAccessor {
     return new RecordAccessor(this, identity);
+  }
+
+  records(type: string): RecordsAccessor {
+    return new RecordsAccessor(this, type);
   }
 
   /**

--- a/addon/-private/store.ts
+++ b/addon/-private/store.ts
@@ -129,11 +129,11 @@ export default class Store {
     this.source.rebase();
   }
 
-  async query(
+  async query<T extends Model = Model>(
     queryOrExpressions: QueryOrExpressions,
     options?: RequestOptions,
     id?: string
-  ): Promise<QueryResult> {
+  ): Promise<QueryResult<T>> {
     const query = buildQuery(
       queryOrExpressions,
       options,
@@ -141,14 +141,14 @@ export default class Store {
       this.source.queryBuilder
     );
     const result = await this.source.query(query);
-    return this.cache.lookup(result, query.expressions.length);
+    return this.cache.lookup<T>(result, query.expressions.length);
   }
 
-  record(identity: RecordIdentity): RecordAccessor {
+  record<T extends Model = Model>(identity: RecordIdentity): RecordAccessor<T> {
     return new RecordAccessor(this, identity);
   }
 
-  records(type: string): RecordsAccessor {
+  records<T extends Model = Model>(type: string): RecordsAccessor<T> {
     return new RecordsAccessor(this, type);
   }
 

--- a/addon/-private/store.ts
+++ b/addon/-private/store.ts
@@ -5,7 +5,6 @@ import {
   RecordIdentity,
   Transform,
   TransformOrOperations,
-  cloneRecordIdentity,
   RecordOperation,
   KeyMap,
   Schema,
@@ -18,7 +17,6 @@ import { destroy, associateDestroyableChild } from '@ember/destroyable';
 import Cache from './cache';
 import Model, { QueryResult } from './model';
 import ModelFactory from './model-factory';
-import normalizeRecordProperties from './utils/normalize-record-properties';
 import { RecordAccessor, RecordsAccessor } from './accessors';
 
 const { deprecate } = Orbit;
@@ -131,23 +129,6 @@ export default class Store {
     this.source.rebase();
   }
 
-  liveQuery(
-    queryOrExpressions: QueryOrExpressions,
-    options?: RequestOptions,
-    id?: string
-  ): Promise<any> {
-    deprecate(
-      '`Store.liveQuery(query)` is deprecated, use `Store.cache.liveQuery(query)`.'
-    );
-    const query = buildQuery(
-      queryOrExpressions,
-      options,
-      id,
-      this.source.queryBuilder
-    );
-    return this.source.query(query).then(() => this.cache.liveQuery(query));
-  }
-
   async query(
     queryOrExpressions: QueryOrExpressions,
     options?: RequestOptions,
@@ -172,44 +153,49 @@ export default class Store {
   }
 
   /**
-   * Adds a record to the Orbit store
-   * @method addRecord
-   * @param {object} properties
-   * @param {object} options
+   * @deprecated
    */
   async addRecord(properties = {}, options?: RequestOptions): Promise<Model> {
-    let record = normalizeRecordProperties(this.source.schema, properties);
-    await this.update((t) => t.addRecord(record), options);
-    return this.cache.lookup(record) as Model;
+    deprecate(
+      '`Store.removeRecord(record)` is deprecated, use `Store.records(type).add()`.'
+    );
+    return this.records((properties as RecordIdentity).type).add(
+      properties,
+      options
+    );
   }
 
+  /**
+   * @deprecated
+   */
   async updateRecord(
     properties = {},
     options?: RequestOptions
   ): Promise<Model> {
-    let record = normalizeRecordProperties(this.source.schema, properties);
-    await this.update((t) => t.updateRecord(record), options);
-    return this.cache.lookup(record) as Model;
+    deprecate(
+      '`Store.removeRecord(record)` is deprecated, use `Store.record(record).update()`.'
+    );
+    return this.record(properties as RecordIdentity).update(
+      properties,
+      options
+    );
   }
 
   /**
-   * Removes a record from the Orbit store
-   * @method removeRecord
-   * @param {RecordIdentity} record
-   * @param {object} options
+   * @deprecated
    */
   async removeRecord(
     record: RecordIdentity,
     options?: RequestOptions
   ): Promise<void> {
-    const identity = cloneRecordIdentity(record);
-    await this.update((t) => t.removeRecord(identity), options);
+    deprecate(
+      '`Store.removeRecord(record)` is deprecated, use `Store.record(record).remove()`.'
+    );
+    await this.record(record).remove(options);
   }
 
   /**
-   * @method find
-   * @param {string} type
-   * @param {string} id
+   * @deprecated
    */
   find(type: string, id?: string | undefined): Promise<Model | Model[]> {
     if (id === undefined) {
@@ -219,18 +205,28 @@ export default class Store {
     }
   }
 
+  /**
+   * @deprecated
+   */
   findRecord(
     type: string,
     id: string,
     options?: RequestOptions
   ): Promise<Model> {
-    return this.query((q) => q.findRecord({ type, id }), options) as Promise<
-      Model
-    >;
+    deprecate(
+      '`Store.findRecord(type, id)` is deprecated, use `Store.record({ type, id }).query()`.'
+    );
+    return this.record({ type, id }).query(options);
   }
 
+  /**
+   * @deprecated
+   */
   findRecords(type: string, options?: RequestOptions): Promise<Model[]> {
-    return this.query((q) => q.findRecords(type), options) as Promise<Model[]>;
+    deprecate(
+      '`Store.findRecords(type)` is deprecated, use `Store.records(type).query()`.'
+    );
+    return this.records(type).query(options);
   }
 
   findRecordByKey(
@@ -246,12 +242,24 @@ export default class Store {
     );
   }
 
+  /**
+   * @deprecated
+   */
   peekRecord(type: string, id: string): Model | undefined {
-    return this.cache.peekRecord(type, id);
+    deprecate(
+      '`Store.peekRecord(type, id)` is deprecated, use `Store.record({ type, id }).peek()`.'
+    );
+    return this.record({ type, id }).peek();
   }
 
-  peekRecords(type: string): Model[] {
-    return this.cache.peekRecords(type);
+  /**
+   * @deprecated
+   */
+  peekRecords(type: string): Model[] | undefined {
+    deprecate(
+      '`Store.peekRecords(type)` is deprecated, use `Store.records(type).peek()`.'
+    );
+    return this.records(type).peek();
   }
 
   peekRecordByKey(


### PR DESCRIPTION
This is an iteration over #240 and #241. I think ultimately we could deprecate almost all of store/cache finder methods.

```ts
store.record({ type: 'planet', id: '1' }).peek();
await store.record({ type: 'planet', id: '1' }).query();
await store.record({ type: 'planet', id: '1' }).remove();
await store.record({ type: 'planet', id: '1' }).update({ name: 'Earth' });

store.records('planet').peek();
store.records('planet').filter({ attribute: 'name', value: 'Earth' }).peek();
store.records('planet').filter({ attribute: 'name', value: 'Earth' }).raw();
store.records('planet').filter({ attribute: 'name', value: 'Earth' }).live();
await store.records('planet').query();
await store.records('planet').filter({ attribute: 'name', value: 'Earth' }).query();
await store.records('planet').add({ name: 'Jupiter' });

record.relatedRecords('moons').peek();
record.relatedRecords('moons').filter({ attribute: 'name', value: 'Moon' }).peek();
record.relatedRecords('moons').filter({ attribute: 'name', value: 'Moon' }).live();
await record.relatedRecords('moons').query();
await record.relatedRecords('moons').filter({ attribute: 'name', value: 'Moon' }).query();
await record.relatedRecords('moons').add({ type: 'moon', id: '1' });
await record.relatedRecords('moons').remove({ type: 'moon', id: '1' });
```

- [x] Add deprecations
- [ ] Add tests