### PR TITLE
Expose base store on forked stores

### DIFF
--- a/tests/integration/store-test.js
+++ b/tests/integration/store-test.js
@@ -430,6 +430,7 @@ module('Integration - Store', function (hooks) {
       classification: 'gas giant'
     });
 
+    assert.equal(forkedStore.base, store);
     assert.notOk(
       store.cache.includesRecord('planet', jupiter.id),
       'store does not contain record'


### PR DESCRIPTION
Bonus is that we destroy forked stores if base store is destroyed. The main benefit of this is in tests. But also in case of deeply nested forked stores it might avoid some memory leaks.