### PR TITLE
Fix immutable record exceptions

### DIFF
--- a/addon/-private/fields/attr.ts
+++ b/addon/-private/fields/attr.ts
@@ -28,6 +28,7 @@ export default function attr(
       const oldValue = this.getAttribute(property);
 
       if (value !== oldValue) {
+        this.assertMutableModel();
         this.replaceAttribute(property, value).catch(() =>
           getCache(this).notifyPropertyChange()
         );

--- a/addon/-private/fields/has-one.ts
+++ b/addon/-private/fields/has-one.ts
@@ -30,6 +30,7 @@ export default function hasOne(
       const oldValue = this.getRelatedRecord(property);
 
       if (value !== oldValue) {
+        this.assertMutableModel();
         this.replaceRelatedRecord(property, value).catch(() =>
           getCache(this).notifyPropertyChange()
         );

--- a/addon/-private/fields/key.ts
+++ b/addon/-private/fields/key.ts
@@ -25,6 +25,7 @@ export default function key(options: Model | KeyDefinition = {}, _?: unknown) {
       const oldValue = this.getKey(property);
 
       if (value !== oldValue) {
+        this.assertMutableModel();
         this.replaceKey(property, value).catch(() =>
           getCache(this).notifyPropertyChange()
         );

--- a/addon/-private/model.ts
+++ b/addon/-private/model.ts
@@ -66,7 +66,7 @@ export default class Model {
     value: string,
     options?: RequestOptions
   ): Promise<void> {
-    this.assertMutable();
+    this.assertMutableModel();
     await this.store.update(
       (t) => t.replaceKey(this.identity, key, value),
       options
@@ -82,7 +82,7 @@ export default class Model {
     value: unknown,
     options?: RequestOptions
   ): Promise<void> {
-    this.assertMutable();
+    this.assertMutableModel();
     await this.store.update(
       (t) => t.replaceAttribute(this.identity, attribute, value),
       options
@@ -98,7 +98,7 @@ export default class Model {
     relatedRecord: Model | null,
     options?: RequestOptions
   ): Promise<void> {
-    this.assertMutable();
+    this.assertMutableModel();
     await this.store.update(
       (t) =>
         t.replaceRelatedRecord(
@@ -128,7 +128,7 @@ export default class Model {
     record: Model,
     options?: RequestOptions
   ): Promise<void> {
-    this.assertMutable();
+    this.assertMutableModel();
     await this.store.update(
       (t) =>
         t.addToRelatedRecords(this.identity, relationship, record.identity),
@@ -141,7 +141,7 @@ export default class Model {
     record: Model,
     options?: RequestOptions
   ): Promise<void> {
-    this.assertMutable();
+    this.assertMutableModel();
     await this.store.update(
       (t) =>
         t.removeFromRelatedRecords(
@@ -157,7 +157,7 @@ export default class Model {
     properties: Dict<unknown> = {},
     options?: RequestOptions
   ): Promise<void> {
-    this.assertMutable();
+    this.assertMutableModel();
     const keys = Object.keys(properties);
     await this.store
       .update(
@@ -174,12 +174,12 @@ export default class Model {
     properties: Dict<unknown> = {},
     options?: RequestOptions
   ): Promise<void> {
-    this.assertMutable();
+    this.assertMutableModel();
     await this.store.updateRecord({ ...properties, ...this.identity }, options);
   }
 
   async remove(options?: RequestOptions): Promise<void> {
-    this.assertMutable();
+    this.assertMutableModel();
     await this.store.removeRecord(this.identity, options);
   }
 
@@ -195,19 +195,19 @@ export default class Model {
     Reflect.getMetadata('orbit:notifier', this, key)(this);
   }
 
+  assertMutableModel(): void {
+    assert(
+      `You tried to change ${this.type}:${this.id} record but it is part of a readonly store. Fork the store to make changes.`,
+      this.#mutable
+    );
+  }
+
   private get store(): Store {
     if (!this.#store) {
       throw new Error('record has been removed from Store');
     }
 
     return this.#store;
-  }
-
-  private assertMutable(): void {
-    assert(
-      `You tried to change ${this.type}:${this.id} record but it is part of a readonly store. Fork the store to make changes.`,
-      this.#mutable
-    );
   }
 
   static get keys(): Dict<KeyDefinition> {

--- a/tests/integration/model-test.js
+++ b/tests/integration/model-test.js
@@ -508,4 +508,15 @@ module('Integration - Model', function (hooks) {
       'invalidates has many relationship'
     );
   });
+
+  test('#base store', async function (assert) {
+    const jupiter = await store.base.addRecord({
+      type: 'planet',
+      name: 'Jupiter'
+    });
+
+    assert.throws(() => {
+      jupiter.name = 'Jupiter2';
+    }, /is part of a readonly store/);
+  });
 });


### PR DESCRIPTION
The problem is that right now the assert is caught by the catch that is there to revert model cache in case of an error. There multiple problems here. The problem is that `planet.name = 'Earth'` is a sync operation, but it will execute in background an async operation. It means there is no way to catch exceptions. `try { planet.name = 'Earth'; } catch (e) {}` will not work because exceptions are thrown from an async operation executed in the background. This PR in its current form just puts some lipstick on the pig by running assert as a sync operation before scheduling the update. I don’t think this is an acceptable solution in it current form. Posting the PR to demonstrate the problem. We can do a `0.17-beta` release but I think we should hold the final `0.17` until I have a reasonable fix for this situation. I am actively working on it.