### PR TITLE
Only restrict mutations on model fields for non-forked stores

### DIFF
--- a/addon/-private/fields/attr.ts
+++ b/addon/-private/fields/attr.ts
@@ -28,7 +28,7 @@ export default function attr(
       const oldValue = this.getAttribute(property);
 
       if (value !== oldValue) {
-        this.assertMutableModel();
+        this.assertMutableFields();
         this.replaceAttribute(property, value).catch(() =>
           getCache(this).notifyPropertyChange()
         );

--- a/addon/-private/fields/has-one.ts
+++ b/addon/-private/fields/has-one.ts
@@ -30,7 +30,7 @@ export default function hasOne(
       const oldValue = this.getRelatedRecord(property);
 
       if (value !== oldValue) {
-        this.assertMutableModel();
+        this.assertMutableFields();
         this.replaceRelatedRecord(property, value).catch(() =>
           getCache(this).notifyPropertyChange()
         );

--- a/addon/-private/fields/key.ts
+++ b/addon/-private/fields/key.ts
@@ -25,7 +25,7 @@ export default function key(options: Model | KeyDefinition = {}, _?: unknown) {
       const oldValue = this.getKey(property);
 
       if (value !== oldValue) {
-        this.assertMutableModel();
+        this.assertMutableFields();
         this.replaceKey(property, value).catch(() =>
           getCache(this).notifyPropertyChange()
         );

--- a/addon/-private/model-factory.ts
+++ b/addon/-private/model-factory.ts
@@ -11,12 +11,12 @@ interface Factory {
 export default class ModelFactory {
   #store: Store;
   #modelFactoryMap: Dict<Factory>;
-  #mutableModels: boolean;
+  #mutableModelFields: boolean;
 
-  constructor(store: Store, mutableModels: boolean) {
+  constructor(store: Store, mutableModelFields: boolean) {
     this.#store = store;
     this.#modelFactoryMap = {};
-    this.#mutableModels = mutableModels;
+    this.#mutableModelFields = mutableModelFields;
   }
 
   create(identity: RecordIdentity): Model {
@@ -24,7 +24,7 @@ export default class ModelFactory {
     return modelFactory.create({
       identity: cloneRecordIdentity(identity),
       store: this.#store,
-      mutable: this.#mutableModels
+      mutableFields: this.#mutableModelFields
     });
   }
 

--- a/addon/-private/store.ts
+++ b/addon/-private/store.ts
@@ -24,7 +24,7 @@ const { deprecate } = Orbit;
 
 export interface StoreSettings {
   source: MemorySource;
-  mutableModels?: boolean;
+  mutableModelFields?: boolean;
   base?: Store;
 }
 
@@ -51,7 +51,7 @@ export default class Store {
       sourceCache: this.source.cache,
       modelFactory: new ModelFactory(
         this,
-        this.forked || settings.mutableModels === true
+        this.forked || settings.mutableModelFields === true
       )
     });
 

--- a/tests/integration/model-test.js
+++ b/tests/integration/model-test.js
@@ -517,6 +517,6 @@ module('Integration - Model', function (hooks) {
 
     assert.throws(() => {
       jupiter.name = 'Jupiter2';
-    }, /is part of a readonly store/);
+    }, /is not allowed on a store that is not a fork/);
   });
 });


### PR DESCRIPTION
This refactor more narrowly confines the concept of "mutable models", introduced in #274, to mean direct mutation of model fields. For a store that is not a fork, direct sync mutation of model fields will be prevented, but async mutation through methods like `replaceAttribute` or `update` will still be allowed.

This prevents the common pitfalls associated with setting `planet.name = 'somethingInvalid';` - namely that changes aren't reflected immediately in records and any async errors won't be caught. However, it still allows `await planet.replaceAttribute('name', 'somethingInvalid')`, which is less ergonomic but more robust. If direct sync mutation is needed, say for two-way-bound inputs in a form, it's recommended that a fork be created which will still allow this approach.