### PR TITLE
Allow easier template access to liveQuery collections

### DIFF
--- a/addon/-private/live-query.ts
+++ b/addon/-private/live-query.ts
@@ -16,7 +16,7 @@ import Cache from './cache';
 import { QueryResult } from './model';
 import { Model } from 'ember-orbit';
 
-const { assert, deprecate } = Orbit;
+const { assert } = Orbit;
 
 export interface LiveQuerySettings {
   liveQuery: SyncLiveQuery;
@@ -62,13 +62,14 @@ export default class LiveQuery implements Iterable<Model> {
     return getValue(this.#value);
   }
 
+  get length(): number {
+    return (this.value as Model[]).length;
+  }
+
   [Symbol.iterator](): IterableIterator<Model> {
     assert(
-      'LiveQuery result is not a collection. You can access it result as `liveQuery.value`.',
+      'LiveQuery result is not a collection. You can access the result as `liveQuery.value`.',
       Array.isArray(this.value)
-    );
-    deprecate(
-      'Using LiveQuery as an iterable is deprecated. Use `liveQuery.value` instead.'
     );
 
     this.#iteratorAccessed = true;

--- a/tests/dummy/app/components/planets-list.hbs
+++ b/tests/dummy/app/components/planets-list.hbs
@@ -5,3 +5,4 @@
     </li>
   {{/each}}
 </ul>
+<div class="planets-count">{{@planets.length}}</div>

--- a/tests/integration/rendering-test.js
+++ b/tests/integration/rendering-test.js
@@ -73,7 +73,7 @@ module('Rendering', function (hooks) {
     assert.dom('.planets').includesText('Earth');
   });
 
-  test('liveQuery records', async function (assert) {
+  test('liveQuery records - accessed via liveQuery.value', async function (assert) {
     const planets = cache.liveQuery((q) => q.findRecords('planet'));
     this.set('planets', planets);
 
@@ -84,8 +84,31 @@ module('Rendering', function (hooks) {
     await store.addRecord({ type: 'planet', name: 'Jupiter' });
     assert.dom('.planets').includesText('Jupiter');
 
+    assert.dom('.planets-count').includesText('1');
+
     await store.addRecord({ type: 'planet', name: 'Earth' });
     assert.dom('.planets').includesText('Earth');
+
+    assert.dom('.planets-count').includesText('2');
+  });
+
+  test('liveQuery records - accessed via liveQuery directly', async function (assert) {
+    const planets = cache.liveQuery((q) => q.findRecords('planet'));
+    this.set('planets', planets);
+
+    await render(hbs`<PlanetsList @planets={{this.planets}} />`);
+
+    assert.dom('.planets').hasNoText();
+
+    await store.addRecord({ type: 'planet', name: 'Jupiter' });
+    assert.dom('.planets').includesText('Jupiter');
+
+    assert.dom('.planets-count').includesText('1');
+
+    await store.addRecord({ type: 'planet', name: 'Earth' });
+    assert.dom('.planets').includesText('Earth');
+
+    assert.dom('.planets-count').includesText('2');
   });
 
   test('liveQuery record', async function (assert) {


### PR DESCRIPTION
* Remove deprecation when accessing `LiveQuery` as an iterator
* Introduce `length` property which proxies to `this.value.length`