### PR TITLE
Fix prototype leakage on inheritance

### DIFF
--- a/addon/-private/model.ts
+++ b/addon/-private/model.ts
@@ -16,10 +16,8 @@ import {
 import { DEBUG } from '@glimmer/env';
 
 import Store from './store';
-import {
-  getModelDefinition,
-  getPropertyNotifiers
-} from './utils/model-definition';
+import { getModelDefinition } from './utils/model-definition';
+import { notifyPropertyChange } from './utils/property-cache';
 
 const { assert } = Orbit;
 
@@ -188,7 +186,7 @@ export default class Model {
   }
 
   notifyPropertyChange(key: string) {
-    getPropertyNotifiers(Object.getPrototypeOf(this))[key](this);
+    notifyPropertyChange(this, key);
   }
 
   assertMutableFields(): void {

--- a/addon/-private/utils/property-cache.ts
+++ b/addon/-private/utils/property-cache.ts
@@ -1,7 +1,14 @@
 import { tracked } from '@glimmer/tracking';
 import { createCache, getValue } from '@glimmer/tracking/primitives/cache';
+import { Orbit } from '@orbit/core';
+import { DEBUG } from '@glimmer/env';
+
+import Model from '../model';
+
+const { deprecate } = Orbit;
 
 const values = new WeakMap<Cache<unknown>, unknown>();
+const caches = new WeakMap<Model, Record<string, Cache<unknown>>>();
 
 export class Cache<T> {
   @tracked invalidate = 0;
@@ -32,4 +39,117 @@ export class Cache<T> {
     values.delete(this);
     this.invalidate++;
   }
+}
+
+export function notifyPropertyChange(record: Model, property: string) {
+  const cache = caches.get(record);
+  if (cache && cache[property]) {
+    cache[property].notifyPropertyChange();
+  }
+}
+
+export function getKeyCache(record: Model, property: string): Cache<unknown> {
+  let cache = caches.get(record);
+
+  if (!cache) {
+    cache = {};
+    caches.set(record, cache);
+  }
+  if (!cache[property]) {
+    cache[property] = new Cache(() => record.getKey(property));
+  }
+
+  return cache[property];
+}
+
+export function getAttributeCache(
+  record: Model,
+  property: string
+): Cache<unknown> {
+  let cache = caches.get(record);
+
+  if (!cache) {
+    cache = {};
+    caches.set(record, cache);
+  }
+  if (!cache[property]) {
+    cache[property] = new Cache(() => record.getAttribute(property));
+  }
+
+  return cache[property];
+}
+
+export function getHasOneCache(
+  record: Model,
+  property: string
+): Cache<unknown> {
+  let cache = caches.get(record);
+
+  if (!cache) {
+    cache = {};
+    caches.set(record, cache);
+  }
+  if (!cache[property]) {
+    cache[property] = new Cache(() => record.getRelatedRecord(property));
+  }
+
+  return cache[property];
+}
+
+export function getHasManyCache(
+  record: Model,
+  property: string
+): Cache<unknown> {
+  let cache = caches.get(record);
+
+  if (!cache) {
+    cache = {};
+    caches.set(record, cache);
+  }
+  if (!cache[property]) {
+    cache[property] = new Cache(() =>
+      addLegacyMutationMethods(
+        record,
+        property,
+        record.getRelatedRecords(property) || []
+      )
+    );
+  }
+
+  return cache[property];
+}
+
+function addLegacyMutationMethods(
+  owner: Model,
+  relationship: string,
+  records: ReadonlyArray<Model>
+) {
+  if (DEBUG) {
+    records = [...records];
+  }
+
+  Object.defineProperties(records, {
+    pushObject: {
+      value: (record: Model) => {
+        deprecate(
+          'pushObject(record) is deprecated. Use record.addToRelatedRecords(relationship, record)'
+        );
+        owner.addToRelatedRecords(relationship, record);
+      }
+    },
+    removeObject: {
+      value: (record: Model) => {
+        deprecate(
+          'removeObject(record) is deprecated. Use record.removeFromRelatedRecords(relationship, record)'
+        );
+        owner.removeFromRelatedRecords(relationship, record);
+      }
+    }
+  });
+
+  if (DEBUG) {
+    return Object.freeze(records);
+  }
+
+  return records;
 }

--- a/tests/integration/model-test.js
+++ b/tests/integration/model-test.js
@@ -3,6 +3,7 @@ import {
   Planet,
   Moon,
   Star,
+  Ocean,
   BinaryStar,
   PlanetarySystem
 } from 'dummy/tests/support/dummy-models';
@@ -19,6 +20,7 @@ module('Integration - Model', function (hooks) {
       planet: Planet,
       moon: Moon,
       star: Star,
+      ocean: Ocean,
       binaryStar: BinaryStar,
       planetarySystem: PlanetarySystem
     };

--- a/tests/integration/store-test.js
+++ b/tests/integration/store-test.js
@@ -2,6 +2,7 @@ import {
   Planet,
   Moon,
   Star,
+  Ocean,
   BinaryStar,
   PlanetarySystem
 } from 'dummy/tests/support/dummy-models';
@@ -15,6 +16,7 @@ module('Integration - Store', function (hooks) {
     planet: Planet,
     moon: Moon,
     star: Star,
+    ocean: Ocean,
     binaryStar: BinaryStar,
     planetarySystem: PlanetarySystem
   };

--- a/tests/support/dummy-models.js
+++ b/tests/support/dummy-models.js
@@ -10,27 +10,28 @@ export class Planet extends NamedModel {
   @attr('string') classification;
   @hasOne('star') sun;
   @hasMany('moon', { inverse: 'planet' }) moons;
+  @hasMany('ocean', { inverse: 'planet' }) oceans;
 }
 
-export class Moon extends Model {
-  @attr('string') name;
+export class Moon extends NamedModel {
   @hasOne('planet', { inverse: 'moons' }) planet;
 }
 
-export class Star extends Model {
-  @attr('string') name;
+export class Ocean extends NamedModel {
+  @hasOne('planet', { inverse: 'oceans' }) planet;
+}
+
+export class Star extends NamedModel {
   @hasMany('planet') planets;
   @attr('boolean') isStable;
 }
 
-export class BinaryStar extends Model {
-  @attr('string') name;
+export class BinaryStar extends NamedModel {
   @hasOne('star') starOne;
   @hasOne('star') starTwo;
 }
 
-export class PlanetarySystem extends Model {
-  @attr('string') name;
+export class PlanetarySystem extends NamedModel {
   @hasOne(['binaryStar', 'star']) star;
   @hasMany(['planet', 'moon']) bodies;
 }


### PR DESCRIPTION
This fixes two issues:
- we now clone modelDefinition stored on prototype on each update to avoid leaking
- we now have per instance property cache instead per definition