### PR TITLE
Remove ember-inflector singularize/pluralize

### DIFF
--- a/addon/-private/factories/schema-factory.ts
+++ b/addon/-private/factories/schema-factory.ts
@@ -2,7 +2,6 @@ import { camelize } from '@ember/string';
 import { getOwner } from '@ember/application';
 import { Schema, SchemaSettings } from '@orbit/data';
 import modulesOfType from '../system/modules-of-type';
-import { singularize, pluralize } from 'ember-inflector';
 
 function getRegisteredModels(prefix, modelsCollection) {
   return modulesOfType(prefix, modelsCollection).map(camelize);
@@ -37,14 +36,6 @@ export default {
       }
 
       injections.models = modelSchemas;
-    }
-
-    if (!injections.pluralize) {
-      injections.pluralize = pluralize;
-    }
-
-    if (!injections.singularize) {
-      injections.singularize = singularize;
     }
 
     return new Schema(injections);

--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
     "ember-cache-primitive-polyfill": "^1.0.1",
     "ember-cli-babel": "^7.23.0",
     "ember-cli-typescript": "^4.0.0",
-    "ember-destroyable-polyfill": "^2.0.2",
-    "ember-inflector": "^3.0.1"
+    "ember-destroyable-polyfill": "^2.0.2"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7159,13 +7159,6 @@ ember-export-application-global@^2.0.1:
   resolved "https://registry.yarnpkg.com/ember-export-application-global/-/ember-export-application-global-2.0.1.tgz#b120a70e322ab208defc9e2daebe8d0dfc2dcd46"
   integrity sha512-B7wiurPgsxsSGzJuPFkpBWnaeuCu2PGpG2BjyrfA1VcL7//o+5RSnZqiCEY326y7qmxb2GoCgo0ft03KBU0rRw==
 
-ember-inflector@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/ember-inflector/-/ember-inflector-3.0.1.tgz#04be6df4d7e4000f6d6bd70787cdc995f77be4ab"
-  integrity sha512-fngrwMsnhkBt51KZgwNwQYxgURwV4lxtoHdjxf7RueGZ5zM7frJLevhHw7pbQNGqXZ3N+MRkhfNOLkdDK9kFdA==
-  dependencies:
-    ember-cli-babel "^6.6.0"
-
 ember-load-initializers@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ember-load-initializers/-/ember-load-initializers-2.1.2.tgz#8a47a656c1f64f9b10cecdb4e22a9d52ad9c7efa"


### PR DESCRIPTION
This was throwing warnings in the console about using inflectors from orbit serializers instead.