### PR TITLE
Don't include app/**/* in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,6 @@
     }
   },
   "include": [
-    "app/**/*",
     "addon/**/*",
     "tests/**/*.ts",
     "types/**/*",


### PR DESCRIPTION
Now that this contains JS modules (see https://github.com/orbitjs/ember-orbit/pull/329) tsc will warn us about overwriting files.