### PR TITLE
Inject singleton `normalizer` and `validatorFor` instances into sources

### DIFF
--- a/addon/-private/factories/memory-source-factory.ts
+++ b/addon/-private/factories/memory-source-factory.ts
@@ -1,12 +1,9 @@
 import { MemorySource, MemorySourceSettings } from '@orbit/memory';
-import { ModelAwareNormalizer } from '../utils/model-aware-normalizer';
 
 export default {
   create(injections: MemorySourceSettings): MemorySource {
-    const { schema } = injections;
     injections.name = injections.name ?? 'store';
     injections.cacheSettings = { debounceLiveQueries: false };
-    injections.normalizer = new ModelAwareNormalizer({ schema });
     return new MemorySource(injections);
   }
 };

--- a/addon/-private/factories/normalizer-factory.ts
+++ b/addon/-private/factories/normalizer-factory.ts
@@ -1,0 +1,10 @@
+import {
+  ModelAwareNormalizer,
+  ModelRecordNormalizerSettings
+} from '../utils/model-aware-normalizer';
+
+export default {
+  create(injections: ModelRecordNormalizerSettings): ModelAwareNormalizer {
+    return new ModelAwareNormalizer(injections);
+  }
+};

--- a/addon/-private/factories/validator-factory.ts
+++ b/addon/-private/factories/validator-factory.ts
@@ -1,0 +1,14 @@
+import {
+  buildRecordValidatorFor,
+  StandardRecordValidator
+} from '@orbit/records';
+import { Dict } from '@orbit/utils';
+import { StandardValidator, ValidatorForFn } from '@orbit/validators';
+
+export default {
+  create(injections: {
+    validators?: Dict<StandardValidator | StandardRecordValidator>;
+  }): ValidatorForFn<StandardValidator | StandardRecordValidator> {
+    return buildRecordValidatorFor(injections);
+  }
+};

--- a/addon/-private/utils/model-aware-normalizer.ts
+++ b/addon/-private/utils/model-aware-normalizer.ts
@@ -1,8 +1,10 @@
 import {
   InitializedRecord,
   RecordIdentity,
+  RecordKeyMap,
   RecordKeyValue,
   RecordNormalizer,
+  RecordSchema,
   StandardRecordNormalizer,
   StandardRecordNormalizerSettings,
   UninitializedRecord
@@ -33,6 +35,14 @@ export class ModelAwareNormalizer
 
   constructor(settings: ModelRecordNormalizerSettings) {
     this._normalizer = new StandardRecordNormalizer(settings);
+  }
+
+  get keyMap(): RecordKeyMap | undefined {
+    return this._normalizer.keyMap;
+  }
+
+  get schema(): RecordSchema {
+    return this._normalizer.schema;
   }
 
   normalizeRecordType(type: string): string {

--- a/addon/initializers/ember-orbit-config.ts
+++ b/addon/initializers/ember-orbit-config.ts
@@ -19,11 +19,15 @@ export interface OrbitConfig {
     coordinator: string;
     schema: string;
     keyMap: string;
+    normalizer: string;
+    validator: string;
   };
   skipStoreService: boolean;
   skipCoordinatorService: boolean;
   skipSchemaService: boolean;
   skipKeyMapService: boolean;
+  skipNormalizerService: boolean;
+  skipValidatorService: boolean;
   mutableModels: boolean;
 }
 
@@ -44,12 +48,16 @@ export const DEFAULT_ORBIT_CONFIG: OrbitConfig = {
     store: 'store',
     coordinator: 'data-coordinator',
     schema: 'data-schema',
-    keyMap: 'data-key-map'
+    keyMap: 'data-key-map',
+    normalizer: 'data-normalizer',
+    validator: 'data-validator'
   },
   skipStoreService: false,
   skipCoordinatorService: false,
   skipSchemaService: false,
   skipKeyMapService: false,
+  skipNormalizerService: false,
+  skipValidatorService: false,
   mutableModels: false
 };
 
@@ -62,19 +70,12 @@ export function initialize(application: Application & ApplicationRegistry) {
   const config = deepMerge({}, DEFAULT_ORBIT_CONFIG, envConfig.orbit ?? {});
 
   // Customize pluralization rules
-  if (
-    application.__registry__ &&
-    application.__registry__.resolver &&
-    application.__registry__.resolver.pluralizedTypes
-  ) {
-    application.__registry__.resolver.pluralizedTypes[config.types.bucket] =
-      config.collections.buckets;
-    application.__registry__.resolver.pluralizedTypes[config.types.model] =
-      config.collections.models;
-    application.__registry__.resolver.pluralizedTypes[config.types.source] =
-      config.collections.sources;
-    application.__registry__.resolver.pluralizedTypes[config.types.strategy] =
-      config.collections.strategies;
+  const pluralizedTypes = application.__registry__?.resolver?.pluralizedTypes;
+  if (pluralizedTypes) {
+    pluralizedTypes[config.types.bucket] = config.collections.buckets;
+    pluralizedTypes[config.types.model] = config.collections.models;
+    pluralizedTypes[config.types.source] = config.collections.sources;
+    pluralizedTypes[config.types.strategy] = config.collections.strategies;
   }
 
   application.register('ember-orbit:config', config, {

--- a/addon/initializers/ember-orbit-services.ts
+++ b/addon/initializers/ember-orbit-services.ts
@@ -5,7 +5,9 @@ import Store from '../-private/store';
 import SchemaFactory from '../-private/factories/schema-factory';
 import CoordinatorFactory from '../-private/factories/coordinator-factory';
 import KeyMapFactory from '../-private/factories/key-map-factory';
+import NormalizerFactory from '../-private/factories/normalizer-factory';
 import MemorySourceFactory from '../-private/factories/memory-source-factory';
+import ValidatorFactory from '../-private/factories/validator-factory';
 
 const { deprecate } = Orbit;
 
@@ -41,6 +43,53 @@ export function initialize(application: Application) {
       'schema',
       `service:${orbitConfig.services.schema}`
     );
+  }
+
+  if (!orbitConfig.skipValidatorService) {
+    // Register a validator service
+    application.register(
+      `service:${orbitConfig.services.validator}`,
+      ValidatorFactory
+    );
+
+    // Inject validator into all sources
+    application.inject(
+      orbitConfig.types.source,
+      'validatorFor',
+      `service:${orbitConfig.services.validator}`
+    );
+  }
+
+  if (!orbitConfig.skipNormalizerService) {
+    // Register a normalizer service
+    application.register(
+      `service:${orbitConfig.services.normalizer}`,
+      NormalizerFactory
+    );
+
+    // Inject normalizer into all sources
+    application.inject(
+      orbitConfig.types.source,
+      'normalizer',
+      `service:${orbitConfig.services.normalizer}`
+    );
+
+    // Inject schema into normalizer
+    if (!orbitConfig.skipSchemaService) {
+      application.inject(
+        `service:${orbitConfig.services.normalizer}`,
+        'schema',
+        `service:${orbitConfig.services.schema}`
+      );
+    }
+    // Inject keyMap into normalizer
+    if (!orbitConfig.skipKeyMapService) {
+      application.inject(
+        `service:${orbitConfig.services.normalizer}`,
+        'keyMap',
+        `service:${orbitConfig.services.keyMap}`
+      );
+    }
   }
 
   if (!orbitConfig.skipCoordinatorService) {

--- a/tests/integration/config-test.js
+++ b/tests/integration/config-test.js
@@ -28,7 +28,9 @@ module('Integration - Config', function (hooks) {
             store: 'orbit-store',
             coordinator: 'orbit-coordinator',
             schema: 'data-schema',
-            keyMap: 'orbit-key-map'
+            keyMap: 'orbit-key-map',
+            normalizer: 'orbit-normalizer',
+            validator: 'orbit-validator'
           }
         }
       },
@@ -44,6 +46,11 @@ module('Integration - Config', function (hooks) {
   });
 
   test('registrations respect config', async function (assert) {
+    const schema = owner.lookup('service:data-schema');
+    const keyMap = owner.lookup('service:orbit-key-map');
+    const normalizer = owner.lookup('service:orbit-normalizer');
+    const validatorFor = owner.lookup('service:orbit-validator');
+
     assert.equal(
       owner.lookup('service:orbit-store'),
       store,
@@ -53,13 +60,45 @@ module('Integration - Config', function (hooks) {
       owner.resolveRegistration('orbit-model:planet'),
       'model factory registration is named from configuration'
     );
-    assert.ok(
+    assert.strictEqual(
       owner.lookup('orbit-source:store'),
+      store.source,
       'source registation is named from configuration'
     );
-    assert.ok(
+    assert.strictEqual(
       owner.lookup('orbit-source:store').schema,
-      'schema is injected successfully on sources'
+      schema,
+      'schema is injected into sources'
+    );
+    assert.strictEqual(
+      owner.lookup('orbit-source:store').keyMap,
+      keyMap,
+      'keyMap is injected into sources'
+    );
+    assert.strictEqual(
+      owner.lookup('orbit-source:store').validatorFor,
+      validatorFor,
+      'validatorFor is injected into sources'
+    );
+    assert.strictEqual(
+      normalizer.schema,
+      schema,
+      'schema is injected into normalizer'
+    );
+    assert.strictEqual(
+      normalizer.keyMap,
+      keyMap,
+      'keyMap is injected into normalizer'
+    );
+    assert.strictEqual(
+      owner.lookup('orbit-source:store').queryBuilder.$normalizer,
+      normalizer,
+      'normalizer is injected into sources and assigned to query builders'
+    );
+    assert.strictEqual(
+      owner.lookup('orbit-source:store').transformBuilder.$normalizer,
+      normalizer,
+      'normalizer is injected into sources and assigned to transform builders'
     );
     assert.ok(
       owner.lookup('service:data-schema'),


### PR DESCRIPTION
Use the DI conventions in place to define new `normalizer` and `validator` services and to inject those into all orbit sources.