### PR TITLE
Prefix all standard methods and properties on Model class with `$`

### DIFF
--- a/addon/-private/cache.ts
+++ b/addon/-private/cache.ts
@@ -274,7 +274,7 @@ export default class Cache {
   unload(identity: RecordIdentity): void {
     const record = this._identityMap.get(identity);
     if (record) {
-      record.disconnect();
+      record.$disconnect();
       this._identityMap.delete(identity);
     }
   }
@@ -351,10 +351,7 @@ export default class Cache {
     property: string
   ): void {
     const record = this._identityMap.get(identity);
-
-    if (record) {
-      record.notifyPropertyChange(property);
-    }
+    record?.$notifyPropertyChange(property);
   }
 
   private generatePatchListener(): (operation: RecordOperation) => void {

--- a/addon/-private/fields/attr.ts
+++ b/addon/-private/fields/attr.ts
@@ -36,18 +36,18 @@ export default function attr(
     function get(this: Model): unknown {
       assert(
         `The ${this.type} record has been removed from the store, so we cannot lookup the ${property} attr from the cache.`,
-        !this.disconnected
+        !this.$disconnected
       );
 
       return getAttributeCache(this, property).value;
     }
 
     function set(this: Model, value: unknown) {
-      const oldValue = this.getAttribute(property);
+      const oldValue = this.$getAttribute(property);
 
       if (value !== oldValue) {
-        this.assertMutableFields();
-        this.replaceAttribute(property, value).catch(() =>
+        this.$assertMutableFields();
+        this.$replaceAttribute(property, value).catch(() =>
           getAttributeCache(this, property).notifyPropertyChange()
         );
         getAttributeCache(this, property).value = value;

--- a/addon/-private/fields/has-many.ts
+++ b/addon/-private/fields/has-many.ts
@@ -45,7 +45,7 @@ export default function hasMany(
     function get(this: Model): Model[] {
       assert(
         `The ${this.type} record has been removed from the store, so we cannot lookup the ${property} hasMany from the cache.`,
-        !this.disconnected
+        !this.$disconnected
       );
 
       return getHasManyCache(this, property).value as Model[];

--- a/addon/-private/fields/has-one.ts
+++ b/addon/-private/fields/has-one.ts
@@ -44,18 +44,18 @@ export default function hasOne(
     function get(this: Model): Model | null {
       assert(
         `The ${this.type} record has been removed from the store, so we cannot lookup the ${property} hasOne from the cache.`,
-        !this.disconnected
+        !this.$disconnected
       );
 
       return getHasOneCache(this, property).value as Model | null;
     }
 
     function set(this: Model, value: Model | null) {
-      const oldValue = this.getRelatedRecord(property);
+      const oldValue = this.$getRelatedRecord(property);
 
       if (value !== oldValue) {
-        this.assertMutableFields();
-        this.replaceRelatedRecord(property, value).catch(() =>
+        this.$assertMutableFields();
+        this.$replaceRelatedRecord(property, value).catch(() =>
           getHasOneCache(this, property).notifyPropertyChange()
         );
       }

--- a/addon/-private/fields/key.ts
+++ b/addon/-private/fields/key.ts
@@ -17,18 +17,18 @@ export default function key(options: KeyDefinition = {}): any {
     function get(this: Model): string {
       assert(
         `The ${this.type} record has been removed from the store, so we cannot lookup the ${property} key from the cache.`,
-        !this.disconnected
+        !this.$disconnected
       );
 
       return getKeyCache(this, property).value as string;
     }
 
     function set(this: Model, value: string) {
-      const oldValue = this.getKey(property);
+      const oldValue = this.$getKey(property);
 
       if (value !== oldValue) {
-        this.assertMutableFields();
-        this.replaceKey(property, value).catch(() =>
+        this.$assertMutableFields();
+        this.$replaceKey(property, value).catch(() =>
           getKeyCache(this, property).notifyPropertyChange()
         );
         getKeyCache(this, property).value = value;

--- a/addon/-private/model.ts
+++ b/addon/-private/model.ts
@@ -21,96 +21,205 @@ import Store from './store';
 import { getModelDefinition } from './utils/model-definition';
 import { notifyPropertyChange } from './utils/property-cache';
 
-const { assert } = Orbit;
+const { assert, deprecate } = Orbit;
 
 export interface ModelSettings {
-  identity: RecordIdentity;
   store: Store;
+  identity: RecordIdentity;
   mutableFields: boolean;
 }
 export default class Model {
-  readonly identity!: RecordIdentity;
-
   @tracked protected _store?: Store;
+  #identity: RecordIdentity;
   #mutableFields: boolean;
 
   constructor(settings: ModelSettings) {
-    this.identity = settings.identity;
     this._store = settings.store;
+    this.#identity = settings.identity;
     this.#mutableFields = settings.mutableFields;
     associateDestroyableChild(settings.store, this);
     registerDestructor(this, (record) => settings.store.cache.unload(record));
   }
 
+  get identity(): RecordIdentity {
+    deprecate(
+      '`Model#identity` is deprecated to avoid potential conflicts with field names. Access `$identity` instead.'
+    );
+    return this.#identity;
+  }
+
+  get $identity(): RecordIdentity {
+    return this.#identity;
+  }
+
   get id(): string {
-    return this.identity.id;
+    return this.#identity.id;
   }
 
   get type(): string {
-    return this.identity.type;
+    return this.#identity.type;
   }
 
   get disconnected(): boolean {
+    deprecate(
+      '`Model#disconnected` is deprecated to avoid potential conflicts with field names. Access `$disconnected` instead.'
+    );
+    return this.$disconnected;
+  }
+
+  get $disconnected(): boolean {
     return !this._store;
   }
 
+  /**
+   * @deprecated
+   */
   getData(): InitializedRecord | undefined {
-    return this.store.cache.peekRecordData(this.type, this.id);
+    deprecate(
+      '`Model#getData` is deprecated to avoid potential conflicts with field names. Call `$getData` instead.'
+    );
+    return this.$getData();
   }
 
+  $getData(): InitializedRecord | undefined {
+    return this._store!.cache.peekRecordData(this.type, this.id);
+  }
+
+  /**
+   * @deprecated
+   */
   getKey(field: string): string | undefined {
-    return this.store.cache.peekKey(this.identity, field);
+    deprecate(
+      '`Model#getKey` is deprecated to avoid potential conflicts with field names. Call `$getKey` instead.'
+    );
+    return this.$getKey(field);
   }
 
+  $getKey(field: string): string | undefined {
+    return this._store!.cache.peekKey(this.#identity, field);
+  }
+
+  /**
+   * @deprecated
+   */
   async replaceKey(
     key: string,
     value: string,
     options?: DefaultRequestOptions<RequestOptions>
   ): Promise<void> {
-    await this.store.update(
-      (t) => t.replaceKey(this.identity, key, value),
+    deprecate(
+      '`Model#replaceKey` is deprecated to avoid potential conflicts with field names. Call `$replaceKey` instead.'
+    );
+    await this.$replaceKey(key, value, options);
+  }
+
+  async $replaceKey(
+    key: string,
+    value: string,
+    options?: DefaultRequestOptions<RequestOptions>
+  ): Promise<void> {
+    await this._store!.update(
+      (t) => t.replaceKey(this.#identity, key, value),
       options
     );
   }
 
-  getAttribute(attribute: string): any {
-    return this.store.cache.peekAttribute(this.identity, attribute);
+  /**
+   * @deprecated
+   */
+  getAttribute(attribute: string): unknown {
+    deprecate(
+      '`Model#getAttribute` is deprecated to avoid potential conflicts with field names. Call `$getAttribute` instead.'
+    );
+    return this.$getAttribute(attribute);
   }
 
+  $getAttribute(attribute: string): unknown {
+    return this._store!.cache.peekAttribute(this.#identity, attribute);
+  }
+
+  /**
+   * @deprecated
+   */
   async replaceAttribute(
     attribute: string,
     value: unknown,
     options?: DefaultRequestOptions<RequestOptions>
   ): Promise<void> {
-    await this.store.update(
-      (t) => t.replaceAttribute(this.identity, attribute, value),
+    deprecate(
+      '`Model#replaceAttribute` is deprecated to avoid potential conflicts with field names. Call `$replaceAttribute` instead.'
+    );
+    await this.$replaceAttribute(attribute, value, options);
+  }
+
+  async $replaceAttribute(
+    attribute: string,
+    value: unknown,
+    options?: DefaultRequestOptions<RequestOptions>
+  ): Promise<void> {
+    await this._store!.update(
+      (t) => t.replaceAttribute(this.#identity, attribute, value),
       options
     );
   }
 
+  /**
+   * @deprecated
+   */
   getRelatedRecord(relationship: string): Model | null | undefined {
-    return this.store.cache.peekRelatedRecord(this.identity, relationship);
+    deprecate(
+      '`Model#getRelatedRecord` is deprecated to avoid potential conflicts with field names. Call `$getRelatedRecord` instead.'
+    );
+    return this.$getRelatedRecord(relationship);
   }
 
+  $getRelatedRecord(relationship: string): Model | null | undefined {
+    return this._store!.cache.peekRelatedRecord(this.#identity, relationship);
+  }
+
+  /**
+   * @deprecated
+   */
   async replaceRelatedRecord(
     relationship: string,
     relatedRecord: Model | null,
     options?: DefaultRequestOptions<RequestOptions>
   ): Promise<void> {
-    await this.store.update(
+    deprecate(
+      '`Model#replaceRelatedRecord` is deprecated to avoid potential conflicts with field names. Call `$replaceRelatedRecord` instead.'
+    );
+    await this.$replaceRelatedRecord(relationship, relatedRecord, options);
+  }
+
+  async $replaceRelatedRecord(
+    relationship: string,
+    relatedRecord: Model | null,
+    options?: DefaultRequestOptions<RequestOptions>
+  ): Promise<void> {
+    await this._store!.update(
       (t) =>
         t.replaceRelatedRecord(
-          this.identity,
+          this.#identity,
           relationship,
-          relatedRecord ? relatedRecord.identity : null
+          relatedRecord ? relatedRecord.$identity : null
         ),
       options
     );
   }
 
+  /**
+   * @deprecated
+   */
   getRelatedRecords(relationship: string): ReadonlyArray<Model> | undefined {
-    const records = this.store.cache.peekRelatedRecords(
-      this.identity,
+    deprecate(
+      '`Model#getRelatedRecords` is deprecated to avoid potential conflicts with field names. Call `$getRelatedRecords` instead.'
+    );
+    return this.$getRelatedRecords(relationship);
+  }
+
+  $getRelatedRecords(relationship: string): ReadonlyArray<Model> | undefined {
+    const records = this._store!.cache.peekRelatedRecords(
+      this.#identity,
       relationship
     );
 
@@ -121,81 +230,187 @@ export default class Model {
     return records;
   }
 
+  /**
+   * @deprecated
+   */
   async addToRelatedRecords(
     relationship: string,
     record: Model,
     options?: DefaultRequestOptions<RequestOptions>
   ): Promise<void> {
-    await this.store.update(
+    deprecate(
+      '`Model#addToRelatedRecords` is deprecated to avoid potential conflicts with field names. Call `$addToRelatedRecords` instead.'
+    );
+    await this.$addToRelatedRecords(relationship, record, options);
+  }
+
+  async $addToRelatedRecords(
+    relationship: string,
+    record: Model,
+    options?: DefaultRequestOptions<RequestOptions>
+  ): Promise<void> {
+    await this._store!.update(
       (t) =>
-        t.addToRelatedRecords(this.identity, relationship, record.identity),
+        t.addToRelatedRecords(this.#identity, relationship, record.$identity),
       options
     );
   }
 
+  /**
+   * @deprecated
+   */
   async removeFromRelatedRecords(
     relationship: string,
     record: Model,
     options?: DefaultRequestOptions<RequestOptions>
   ): Promise<void> {
-    await this.store.update(
+    deprecate(
+      '`Model#removeFromRelatedRecords` is deprecated to avoid potential conflicts with field names. Call `$removeFromRelatedRecords` instead.'
+    );
+    await this.$removeFromRelatedRecords(relationship, record, options);
+  }
+
+  async $removeFromRelatedRecords(
+    relationship: string,
+    record: Model,
+    options?: DefaultRequestOptions<RequestOptions>
+  ): Promise<void> {
+    await this._store!.update(
       (t) =>
         t.removeFromRelatedRecords(
-          this.identity,
+          this.#identity,
           relationship,
-          record.identity
+          record.$identity
         ),
       options
     );
   }
 
+  /**
+   * @deprecated
+   */
   async replaceAttributes(
     properties: Dict<unknown>,
     options?: DefaultRequestOptions<RequestOptions>
   ): Promise<void> {
-    const propertyNames = Object.keys(properties);
-    await this.store.update(
-      (t) =>
-        propertyNames.map((name) =>
-          t.replaceAttribute(this.identity, name, properties[name])
-        ),
-      options
+    deprecate(
+      '`Model#replaceAttributes` is deprecated. Call `$update` instead (with the same arguments).'
     );
+    await this.$update(properties, options);
   }
 
+  /**
+   * @deprecated
+   */
   async update(
     properties: Dict<unknown>,
     options?: DefaultRequestOptions<RequestOptions>
   ): Promise<void> {
-    await this.store.updateRecord({ ...properties, ...this.identity }, options);
+    deprecate(
+      '`Model#update` is deprecated to avoid potential conflicts with field names. Call `$update` instead.'
+    );
+    await this.$update(properties, options);
   }
 
+  async $update(
+    properties: Dict<unknown>,
+    options?: DefaultRequestOptions<RequestOptions>
+  ): Promise<void> {
+    await this._store!.update(
+      (t) =>
+        t.updateRecord({
+          ...properties,
+          ...this.#identity
+        }),
+      options
+    );
+  }
+
+  /**
+   * @deprecated
+   */
   async remove(options?: DefaultRequestOptions<RequestOptions>): Promise<void> {
-    await this.store.removeRecord(this.identity, options);
+    deprecate(
+      '`Model#remove` is deprecated to avoid potential conflicts with field names. Call `$remove` instead.'
+    );
+    await this.$remove(options);
   }
 
+  async $remove(
+    options?: DefaultRequestOptions<RequestOptions>
+  ): Promise<void> {
+    await this._store!.update((t) => t.removeRecord(this.#identity), options);
+  }
+
+  /**
+   * @deprecated
+   */
   disconnect(): void {
+    deprecate(
+      '`Model#disconnect` is deprecated to avoid potential conflicts with field names. Call `$disconnect` instead.'
+    );
+    this.$disconnect();
+  }
+
+  $disconnect(): void {
     this._store = undefined;
   }
 
+  /**
+   * @deprecated
+   */
   destroy(): void {
+    deprecate(
+      '`Model#destroy` is deprecated to avoid potential conflicts with field names. Call `$destroy` instead.'
+    );
+    this.$destroy();
+  }
+
+  $destroy(): void {
     destroy(this);
   }
 
+  /**
+   * @deprecated
+   */
   notifyPropertyChange(key: string) {
+    deprecate(
+      '`Model#notifyPropertyChange` is deprecated to avoid potential conflicts with field names. Call `$notifyPropertyChange` instead.'
+    );
+    this.$notifyPropertyChange(key);
+  }
+
+  $notifyPropertyChange(key: string) {
     notifyPropertyChange(this, key);
   }
 
+  /**
+   * @deprecated
+   */
   assertMutableFields(): void {
+    deprecate(
+      '`Model#assertMutableFields` is deprecated to avoid potential conflicts with field names. Call `$assertMutableFields` instead.'
+    );
+    this.$assertMutableFields();
+  }
+
+  $assertMutableFields(): void {
     assert(
       `You tried to directly mutate fields on the '${this.type}:${this.id}' record, which is not allowed on a store that is not a fork. Either make this change using an async method like 'update' or 'replaceAttribute' or fork the store if you need to directly mutate fields on a record.`,
       this.#mutableFields
     );
   }
 
-  protected get store(): Store {
+  get store(): Store {
+    deprecate(
+      '`Model#store` is deprecated to avoid potential conflicts with field names. Access `$store` instead.'
+    );
+    return this.$store;
+  }
+
+  get $store(): Store {
     if (!this._store) {
-      throw new Error('record has been removed from Store');
+      throw new Error('record has been removed its store');
     }
 
     return this._store;

--- a/addon/-private/utils/model-aware-normalizer.ts
+++ b/addon/-private/utils/model-aware-normalizer.ts
@@ -53,7 +53,7 @@ export class ModelAwareNormalizer
     identity: RecordIdentity | RecordKeyValue | Model
   ): RecordIdentity {
     if (identity instanceof Model) {
-      return identity.identity;
+      return identity.$identity;
     } else {
       return this._normalizer.normalizeRecordIdentity(identity);
     }
@@ -61,7 +61,7 @@ export class ModelAwareNormalizer
 
   normalizeRecord(record: RecordFieldsOrModel): InitializedRecord {
     if (record instanceof Model) {
-      let data = record.getData();
+      let data = record.$getData();
       if (data === undefined) {
         throw new Error('Model is no longer in the cache');
       } else {

--- a/addon/-private/utils/property-cache.ts
+++ b/addon/-private/utils/property-cache.ts
@@ -67,7 +67,7 @@ export function getKeyCache(
 
   if (propertyCache === undefined) {
     propertyCache = recordCaches[property] = new PropertyCache(() =>
-      record.getKey(property)
+      record.$getKey(property)
     );
   }
 
@@ -89,7 +89,7 @@ export function getAttributeCache(
 
   if (propertyCache === undefined) {
     propertyCache = recordCaches[property] = new PropertyCache(() =>
-      record.getAttribute(property)
+      record.$getAttribute(property)
     );
   }
 
@@ -111,7 +111,7 @@ export function getHasOneCache(
 
   if (propertyCache === undefined) {
     propertyCache = recordCaches[property] = new PropertyCache(() =>
-      record.getRelatedRecord(property)
+      record.$getRelatedRecord(property)
     );
   }
 
@@ -136,7 +136,7 @@ export function getHasManyCache(
       addLegacyMutationMethods(
         record,
         property,
-        record.getRelatedRecords(property) ?? []
+        record.$getRelatedRecords(property) ?? []
       )
     );
   }
@@ -159,7 +159,7 @@ function addLegacyMutationMethods(
         deprecate(
           'pushObject(record) is deprecated. Use record.addToRelatedRecords(relationship, record)'
         );
-        owner.addToRelatedRecords(relationship, record);
+        owner.$addToRelatedRecords(relationship, record);
       }
     },
     removeObject: {
@@ -167,7 +167,7 @@ function addLegacyMutationMethods(
         deprecate(
           'removeObject(record) is deprecated. Use record.removeFromRelatedRecords(relationship, record)'
         );
-        owner.removeFromRelatedRecords(relationship, record);
+        owner.$removeFromRelatedRecords(relationship, record);
       }
     }
   });

--- a/tests/dummy/app/controllers/filtered.js
+++ b/tests/dummy/app/controllers/filtered.js
@@ -27,7 +27,7 @@ export default class FilteredController extends Controller {
 
   @action
   async duplicatePlanet(planet) {
-    const planetCopy = clone(planet.getData());
+    const planetCopy = clone(planet.$getData());
     planetCopy.id = this.dataSchema.generateId('planet');
     delete planetCopy.relationships;
     await this.store.update((t) => {
@@ -36,7 +36,7 @@ export default class FilteredController extends Controller {
       const operations = [addPlanetOperation];
 
       planet.moons.forEach((moon) => {
-        const moonCopy = clone(moon.getData());
+        const moonCopy = clone(moon.$getData());
         moonCopy.id = this.dataSchema.generateId('moon');
         delete moonCopy.relationships;
         const addMoonOperation = t.addRecord(moonCopy);

--- a/tests/integration/rendering-test.js
+++ b/tests/integration/rendering-test.js
@@ -53,7 +53,7 @@ module('Rendering', function (hooks) {
 
     assert.dom('.moons').includesText('New Europa');
 
-    await europa.remove();
+    await europa.$remove();
 
     assert.dom('.moons').doesNotIncludeText('New Europa');
   });

--- a/tests/integration/store-test.js
+++ b/tests/integration/store-test.js
@@ -378,7 +378,7 @@ module('Integration - Store', function (hooks) {
       sun
     });
     const record = await store.query((q) =>
-      q.findRelatedRecord(jupiter.identity, 'sun')
+      q.findRelatedRecord(jupiter.$identity, 'sun')
     );
     assert.strictEqual(record, sun);
   });
@@ -392,7 +392,7 @@ module('Integration - Store', function (hooks) {
       moons: [io, callisto]
     });
     const records = await store.query((q) =>
-      q.findRelatedRecords(jupiter.identity, 'moons')
+      q.findRelatedRecords(jupiter.$identity, 'moons')
     );
 
     assert.deepEqual(records, [io, callisto]);


### PR DESCRIPTION
As discussed in #283, Orbit's `Model` class has long had the potential for namespace conflicts, since the built-in methods and properties are co-mingled with any custom field properties that access the model's underlying data.

This deprecates all the built-in methods and properties on `Model` and replaces them with versions that are prefixed with `$`.

Thus, for a `Model` instance `planet`, replace calls to `planet.remove()` with `planet.$remove()`. And instead of accessing `planet.store`, access `planet.$store`. The properties `id` and `type` are not deprecated, as they access underlying record data. However, `identity` is an ember-orbit construct and has been deprecated in favor of `$identity`.

Closes #283