### PR TITLE
Introduce Cache#update method

### DIFF
--- a/addon/-private/store.ts
+++ b/addon/-private/store.ts
@@ -7,7 +7,8 @@ import {
   DefaultRequestOptions,
   FullRequestOptions,
   FullResponse,
-  RequestOptions
+  RequestOptions,
+  TransformBuilderFunc
 } from '@orbit/data';
 import MemorySource, { MemorySourceMergeOptions } from '@orbit/memory';
 import { RecordCacheQueryOptions } from '@orbit/record-cache';
@@ -481,7 +482,10 @@ export default class Store {
   }
 
   async sync(
-    transformOrTransforms: RecordTransform | RecordTransform[]
+    transformOrTransforms:
+      | RecordTransform
+      | RecordTransform[]
+      | TransformBuilderFunc<RecordOperation, ModelAwareTransformBuilder>
   ): Promise<void> {
     await this.source.sync(transformOrTransforms);
   }

--- a/package.json
+++ b/package.json
@@ -34,19 +34,19 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
-    "@glimmer/tracking": "^1.0.3",
+    "@glimmer/tracking": "^1.0.4",
     "@orbit/coordinator": "^0.17.0-beta.20",
     "@orbit/core": "^0.17.0-beta.20",
     "@orbit/data": "^0.17.0-beta.20",
-    "@orbit/identity-map": "^0.17.0-beta.20",
-    "@orbit/memory": "^0.17.0-beta.20",
-    "@orbit/records": "^0.17.0-beta.20",
+    "@orbit/identity-map": "^0.17.0-beta.22",
+    "@orbit/memory": "^0.17.0-beta.22",
+    "@orbit/records": "^0.17.0-beta.22",
     "@orbit/utils": "^0.17.0-beta.19",
-    "@orbit/validators": "^0.17.0-beta.19",
-    "ember-auto-import": "^1.10.1",
+    "@orbit/validators": "^0.17.0-beta.22",
+    "ember-auto-import": "^1.11.3",
     "ember-cache-primitive-polyfill": "^1.0.1",
     "ember-cli-babel": "^7.23.1",
-    "ember-cli-typescript": "^4.1.0",
+    "ember-cli-typescript": "^4.2.1",
     "ember-destroyable-polyfill": "^2.0.3"
   },
   "devDependencies": {

--- a/tests/integration/cache-test.ts
+++ b/tests/integration/cache-test.ts
@@ -70,6 +70,33 @@ module('Integration - Cache', function (hooks) {
     assert.equal(id, '123');
   });
 
+  test('#update - addRecord', async function (assert) {
+    const earth = cache.update<Planet>((t) =>
+      t.addRecord({ type: 'planet', name: 'Earth' })
+    );
+    assert.strictEqual(cache.lookup(earth), earth);
+    assert.strictEqual(earth.name, 'Earth');
+  });
+
+  test('#update - [addRecord]', async function (assert) {
+    const [earth] = cache.update<[Planet]>((t) => [
+      t.addRecord({ type: 'planet', name: 'Earth' })
+    ]);
+    assert.strictEqual(cache.lookup(earth), earth);
+    assert.strictEqual(earth.name, 'Earth');
+  });
+
+  test('#update - [addRecord, addRecord]', async function (assert) {
+    const [earth, jupiter] = cache.update<[Planet, Planet]>((t) => [
+      t.addRecord({ type: 'planet', name: 'Earth' }),
+      t.addRecord({ type: 'planet', name: 'Jupiter' })
+    ]);
+    assert.strictEqual(cache.lookup(earth), earth);
+    assert.strictEqual(earth.name, 'Earth');
+    assert.strictEqual(cache.lookup(jupiter), jupiter);
+    assert.strictEqual(jupiter.name, 'Jupiter');
+  });
+
   test('#query - record', async function (assert) {
     const earth = await store.addRecord({ type: 'planet', name: 'Earth' });
     await store.addRecord({ type: 'planet', name: 'Jupiter' });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1193,10 +1193,10 @@
     "@handlebars/parser" "^1.1.0"
     simple-html-tokenizer "^0.5.10"
 
-"@glimmer/tracking@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/tracking/-/tracking-1.0.3.tgz#8b9b42aff6c206edeaaea178a95acc1eff62e61e"
-  integrity sha512-21WR13vPdzt1IQ6JmPPAu4szjV9yKdmLHV3nD0MLDj6/EoYv1c2PqpFBBlp++6xW8OnyDa++cQ8OFoQDP+MRpA==
+"@glimmer/tracking@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/tracking/-/tracking-1.0.4.tgz#f1bc1412fe5e2236d0f8d502994a8f88af1bbb21"
+  integrity sha512-F+oT8I55ba2puSGIzInmVrv/8QA2PcK1VD+GWgFMhF6WC97D+uZX7BFg+a3s/2N4FVBq5KHE+QxZzgazM151Yw==
   dependencies:
     "@glimmer/env" "^0.1.7"
     "@glimmer/validator" "^0.44.0"
@@ -1306,56 +1306,56 @@
     "@orbit/core" "^0.17.0-beta.20"
     "@orbit/utils" "^0.17.0-beta.19"
 
-"@orbit/identity-map@^0.17.0-beta.20":
-  version "0.17.0-beta.20"
-  resolved "https://registry.yarnpkg.com/@orbit/identity-map/-/identity-map-0.17.0-beta.20.tgz#3bbf664338788df6d0b7f57a1176ee8bbbb52486"
-  integrity sha512-+0IsUALwvguinRXr6V8z6dkQPtMgiADPUJ02ZCjUtZHhx1iz/CaPpn/l6fCHR6H6L62tVaqlYHvVI9VDjKIBYw==
+"@orbit/identity-map@^0.17.0-beta.22":
+  version "0.17.0-beta.22"
+  resolved "https://registry.yarnpkg.com/@orbit/identity-map/-/identity-map-0.17.0-beta.22.tgz#5b4916045ff774cf76c72e2f914696175cf755ac"
+  integrity sha512-uzK7lK72z54WgRTf6B5PPiAn7dzqKmZ9sIfaqBdj1hcbb+ThRRjPI/TAJNlIZ6UCf2GSiy51vJaep1mNSF0yDg==
 
 "@orbit/immutable@^0.17.0-beta.14":
   version "0.17.0-beta.14"
   resolved "https://registry.yarnpkg.com/@orbit/immutable/-/immutable-0.17.0-beta.14.tgz#092f85409b82bafda84eaa2280478805ba904ab6"
   integrity sha512-8RAXijo9emE4+3S6n8BT8lsQFnTE8O+NlpnBp9TbMjKeEkZCv3lQNgN+M7iJrYfTMRnhqKPevl2EFyAdqPbsOg==
 
-"@orbit/memory@^0.17.0-beta.20":
-  version "0.17.0-beta.20"
-  resolved "https://registry.yarnpkg.com/@orbit/memory/-/memory-0.17.0-beta.20.tgz#7bd0f453b57a42c6b2a315dc05f24e7bb419590d"
-  integrity sha512-iRnucFjd1IT88kwsrDz4PCx7oRRq+9hNs/1JLq/6nq5ZrlhPrBQQcqIkGgL8Fu9/xg8FdqwIAI5ROI+Xfhjt+Q==
+"@orbit/memory@^0.17.0-beta.22":
+  version "0.17.0-beta.22"
+  resolved "https://registry.yarnpkg.com/@orbit/memory/-/memory-0.17.0-beta.22.tgz#7fb3e24eb83bb001e5815a21c8f418dd6e2b6a62"
+  integrity sha512-N/dt2eaIICSY2DSSjgk+HTPL4q86RbDx5Xanw/ZE2dMfZit+QtLQ3dWCOZ/Wh1vuvRi/hNqcr/YJjez6cGwbAw==
   dependencies:
     "@orbit/core" "^0.17.0-beta.20"
     "@orbit/data" "^0.17.0-beta.20"
     "@orbit/immutable" "^0.17.0-beta.14"
-    "@orbit/record-cache" "^0.17.0-beta.20"
-    "@orbit/records" "^0.17.0-beta.20"
+    "@orbit/record-cache" "^0.17.0-beta.22"
+    "@orbit/records" "^0.17.0-beta.22"
     "@orbit/utils" "^0.17.0-beta.19"
 
-"@orbit/record-cache@^0.17.0-beta.20":
-  version "0.17.0-beta.20"
-  resolved "https://registry.yarnpkg.com/@orbit/record-cache/-/record-cache-0.17.0-beta.20.tgz#b93386c8c387940f7002a9c98665c412543613be"
-  integrity sha512-Hqs8XEbAaXsu4kSTX5gUDPztkqkuJ+P9PuSQd8QU2KpysJybWtzLilgZWq0Vt7oGt2qajMwZL9iibmblIXZU8A==
+"@orbit/record-cache@^0.17.0-beta.22":
+  version "0.17.0-beta.22"
+  resolved "https://registry.yarnpkg.com/@orbit/record-cache/-/record-cache-0.17.0-beta.22.tgz#83f7e440f21fdf1a435790aca2c58084d67ef2fa"
+  integrity sha512-HusBhONU21SFVnY0XsmjhOA44xUCF4lYEUHjcBN7Fqj9oA60szqRRdqbBMorjRbaIMgZhQCXO2RPhOxZ954ivw==
   dependencies:
     "@orbit/core" "^0.17.0-beta.20"
     "@orbit/data" "^0.17.0-beta.20"
-    "@orbit/records" "^0.17.0-beta.20"
+    "@orbit/records" "^0.17.0-beta.22"
     "@orbit/utils" "^0.17.0-beta.19"
 
-"@orbit/records@^0.17.0-beta.20":
-  version "0.17.0-beta.20"
-  resolved "https://registry.yarnpkg.com/@orbit/records/-/records-0.17.0-beta.20.tgz#cf511cfcb220afa8a0f0910977fc7ef878d1ec05"
-  integrity sha512-5Q9/zmgq1Rtp4xT9+fVrTpgEzBppg2SfSUddkKkOkSQd33CfkG3cxoAE0IXCMfeoj3p6+merI4siLawAQ7VqOQ==
+"@orbit/records@^0.17.0-beta.22":
+  version "0.17.0-beta.22"
+  resolved "https://registry.yarnpkg.com/@orbit/records/-/records-0.17.0-beta.22.tgz#eb1130b811a6021af79033dbbc2ec6c1384ab3f6"
+  integrity sha512-lwwdS1s9elUSmFqgeEh+lcPbQ2MbiE5r+aXn26MLRD955PhCzENvm4bf7MkIlP0uwEB5cOcQBacpAGMo/nttbQ==
   dependencies:
     "@orbit/data" "^0.17.0-beta.20"
     "@orbit/utils" "^0.17.0-beta.19"
-    "@orbit/validators" "^0.17.0-beta.19"
+    "@orbit/validators" "^0.17.0-beta.22"
 
 "@orbit/utils@^0.17.0-beta.19":
   version "0.17.0-beta.19"
   resolved "https://registry.yarnpkg.com/@orbit/utils/-/utils-0.17.0-beta.19.tgz#c66f96d73459f84847c0f3e518766d39cbeb8eb2"
   integrity sha512-JMpuVQpIVjY9mwI25TVKxvAvyuujYfNr5zH+QUtx4GZkDW5va50XuFKK6z0IW2FaM9KpUNfLyhTYGH9CV0vBAQ==
 
-"@orbit/validators@^0.17.0-beta.19":
-  version "0.17.0-beta.19"
-  resolved "https://registry.yarnpkg.com/@orbit/validators/-/validators-0.17.0-beta.19.tgz#cc07e87f4aa105af2a987fc9131b962ad5489add"
-  integrity sha512-LV4OD1RZxP3/tk/Rd6SbtTM2tsyYx2vNsDJtvv/GTGCxOFDCeV1fW2jabDvMH0DHmsVaNmKCGaGCVGnIESq5Nw==
+"@orbit/validators@^0.17.0-beta.22":
+  version "0.17.0-beta.22"
+  resolved "https://registry.yarnpkg.com/@orbit/validators/-/validators-0.17.0-beta.22.tgz#9aec4491c567c77d2b71af3507e20c2de93c9bf0"
+  integrity sha512-5Qlvc+sZYekH1FRIADfJnnUOvr0Ow9+XqysmyDQliJg2tP482k9PP1uo2kTIB2x0hIequyrJDiRZ3PC2BpwNKA==
   dependencies:
     "@orbit/utils" "^0.17.0-beta.19"
 
@@ -2054,6 +2054,13 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
+
+ansi-to-html@^0.6.15:
+  version "0.6.15"
+  resolved "https://registry.yarnpkg.com/ansi-to-html/-/ansi-to-html-0.6.15.tgz#ac6ad4798a00f6aa045535d7f6a9cb9294eebea7"
+  integrity sha512-28ijx2aHJGdzbs+O5SNQF65r6rrKYnkuwTYm8lZlChuoJ9P1vVzIpWO20sQTqTPDXYp6NFwk326vApTtLVFXpQ==
+  dependencies:
+    entities "^2.0.0"
 
 ansi-to-html@^0.6.6:
   version "0.6.14"
@@ -4830,6 +4837,41 @@ ember-auto-import@^1.10.1:
     walk-sync "^0.3.3"
     webpack "^4.43.0"
 
+ember-auto-import@^1.11.3:
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/ember-auto-import/-/ember-auto-import-1.11.3.tgz#6e3384a7fbb163384a34546f2e902cd297b0e683"
+  integrity sha512-ekq/XCvsonESobFU30zjZ0I4XMy2E/2ZILCYWuQ1JdhcCSTYhnXDZcqRW8itUG7kbsPqAHT/XZ1LEZYm3seVwQ==
+  dependencies:
+    "@babel/core" "^7.1.6"
+    "@babel/preset-env" "^7.10.2"
+    "@babel/traverse" "^7.1.6"
+    "@babel/types" "^7.1.6"
+    "@embroider/core" "^0.33.0"
+    babel-core "^6.26.3"
+    babel-loader "^8.0.6"
+    babel-plugin-syntax-dynamic-import "^6.18.0"
+    babylon "^6.18.0"
+    broccoli-debug "^0.6.4"
+    broccoli-node-api "^1.7.0"
+    broccoli-plugin "^4.0.0"
+    broccoli-source "^3.0.0"
+    debug "^3.1.0"
+    ember-cli-babel "^7.0.0"
+    enhanced-resolve "^4.0.0"
+    fs-extra "^6.0.1"
+    fs-tree-diff "^2.0.0"
+    handlebars "^4.3.1"
+    js-string-escape "^1.0.1"
+    lodash "^4.17.19"
+    mkdirp "^0.5.1"
+    resolve-package-path "^3.1.0"
+    rimraf "^2.6.2"
+    semver "^7.3.4"
+    symlink-or-copy "^1.2.0"
+    typescript-memoize "^1.0.0-alpha.3"
+    walk-sync "^0.3.3"
+    webpack "^4.43.0"
+
 ember-cache-primitive-polyfill@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ember-cache-primitive-polyfill/-/ember-cache-primitive-polyfill-1.0.1.tgz#a27075443bd87e5af286c1cd8a7df24e3b9f6715"
@@ -5090,12 +5132,12 @@ ember-cli-typescript@^3.1.4:
     stagehand "^1.0.0"
     walk-sync "^2.0.0"
 
-ember-cli-typescript@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-4.1.0.tgz#2ff17be2e6d26b58c88b1764cb73887e7176618b"
-  integrity sha512-zSuKG8IQuYE3vS+c7V0mHJqwrN/4Wo9Wr50+0NUjnZH3P99ChynczQHu/P7WSifkO6pF6jaxwzf09XzWvG8sVw==
+ember-cli-typescript@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz#54d08fc90318cc986f3ea562f93ce58a6cc4c24d"
+  integrity sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==
   dependencies:
-    ansi-to-html "^0.6.6"
+    ansi-to-html "^0.6.15"
     broccoli-stew "^3.0.0"
     debug "^4.0.0"
     execa "^4.0.0"
@@ -5548,6 +5590,11 @@ entities@^1.1.2, entities@~1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
   integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
+
+entities@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
+  integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
 
 entities@~2.1.0:
   version "2.1.0"


### PR DESCRIPTION
As requested in #348, this introduces an `update` method to the ember-orbit `Cache`. This invokes `update` on the underlying orbit cache and returns model(s) in responses as appropriate.

This PR also updates Orbit and other dependencies, and fixes typing on `Store#sync`.