### PR TITLE
Model#$getData should never successfully return undefined

### DIFF
--- a/addon/-private/model.ts
+++ b/addon/-private/model.ts
@@ -73,15 +73,24 @@ export default class Model {
   /**
    * @deprecated
    */
-  getData(): InitializedRecord | undefined {
+  getData(): InitializedRecord {
     deprecate(
       '`Model#getData` is deprecated to avoid potential conflicts with field names. Call `$getData` instead.'
     );
     return this.$getData();
   }
 
-  $getData(): InitializedRecord | undefined {
-    return this._store!.cache.getRecordData(this.type, this.id);
+  $getData(): InitializedRecord {
+    assert(
+      'Model must be connected to a store in order to call `$getData`',
+      this._store !== undefined
+    );
+    const data = this._store!.cache.getRecordData(this.type, this.id);
+    assert(
+      "`$getData` can not succeed because the record associated with the model no longer exists in its store's cache.",
+      data !== undefined
+    );
+    return data as InitializedRecord;
   }
 
   /**

--- a/tests/integration/model-test.ts
+++ b/tests/integration/model-test.ts
@@ -13,8 +13,8 @@ import { createStore } from 'dummy/tests/support/store';
 import { module, test } from 'qunit';
 import { getOwner } from '@ember/application';
 import { waitForSource } from 'ember-orbit/test-support';
-import { InitializedRecord } from '@orbit/records';
 import { setupTest } from 'ember-qunit';
+import { Assertion } from '@orbit/core';
 
 module('Integration - Model', function (hooks) {
   setupTest(hooks);
@@ -422,11 +422,24 @@ module('Integration - Model', function (hooks) {
       type: 'planet',
       name: 'Jupiter'
     });
-    let recordData = record.$getData() as InitializedRecord;
+    let recordData = record.$getData();
     assert.equal(
       recordData.attributes?.name,
       'Jupiter',
       'returns record data (resource)'
+    );
+  });
+
+  test('$getData fails when record has been removed from its store', async function (assert) {
+    const record = await store.addRecord<Planet>({
+      type: 'planet',
+      name: 'Jupiter'
+    });
+    await record.$remove();
+    assert.throws(
+      () => record.$getData(),
+      Assertion,
+      'Error: Assertion failed: Model must be connected to a store in order to call `$getData`'
     );
   });
 


### PR DESCRIPTION
Raise assertions rather than allow `$getData` to return undefined. `$getData` should never be called for disconnected records with the expectation that it will return successfully.