### PR TITLE
Allow undefined responses from update / merge

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
           - ember-lts-3.20
           - ember-release
           - ember-beta
-          - ember-canary
+          # - ember-canary
           - ember-default-with-jquery
           - ember-classic
 

--- a/addon/-private/cache.ts
+++ b/addon/-private/cache.ts
@@ -274,24 +274,29 @@ export default class Cache {
     );
 
     if (options?.fullResponse) {
-      const response = this.#sourceCache.update(transform, {
+      let response = this.#sourceCache.update(transform, {
         fullResponse: true
       });
-      const data = this._lookupTransformResult(
-        response.data,
-        Array.isArray(transform.operations)
-      );
-      return {
-        ...response,
-        data
-      } as FullResponse<RequestData, unknown, RecordOperation>;
+      if (response.data !== undefined) {
+        const data = this._lookupTransformResult(
+          response.data,
+          Array.isArray(transform.operations)
+        );
+        response = {
+          ...response,
+          data
+        };
+      }
+      return response as FullResponse<RequestData, unknown, RecordOperation>;
     } else {
-      const response = this.#sourceCache.update(transform);
-      const data = this._lookupTransformResult(
-        response,
-        Array.isArray(transform.operations)
-      );
-      return data as RequestData;
+      let response = this.#sourceCache.update(transform);
+      if (response !== undefined) {
+        response = this._lookupTransformResult(
+          response,
+          Array.isArray(transform.operations)
+        );
+      }
+      return response as RequestData;
     }
   }
 

--- a/addon/-private/store.ts
+++ b/addon/-private/store.ts
@@ -207,7 +207,7 @@ export default class Store {
     RequestData | FullResponse<RequestData, unknown, RecordOperation>
   > {
     if (options?.fullResponse) {
-      const response = (await this.source.merge(
+      let response = (await this.source.merge(
         forkedStore.source,
         options as FullRequestOptions<RequestOptions> & MemorySourceMergeOptions
       )) as FullResponse<
@@ -215,25 +215,30 @@ export default class Store {
         unknown,
         RecordOperation
       >;
-      const data = this.cache._lookupTransformResult(
-        response.data,
-        true // merge results should ALWAYS be an array
-      );
-      return {
-        ...response,
-        data
-      } as FullResponse<RequestData, undefined, RecordOperation>;
+      if (response.data !== undefined) {
+        const data = this.cache._lookupTransformResult(
+          response.data,
+          true // merge results should ALWAYS be an array
+        );
+        response = {
+          ...response,
+          data
+        };
+      }
+      return response as FullResponse<RequestData, unknown, RecordOperation>;
     } else {
-      const response = (await this.source.merge(
+      let response = (await this.source.merge(
         forkedStore.source,
         options as DefaultRequestOptions<RequestOptions> &
           MemorySourceMergeOptions
       )) as RecordTransformResult<InitializedRecord>;
-      const data = this.cache._lookupTransformResult(
-        response,
-        true // merge results should ALWAYS be an array
-      );
-      return data as RequestData;
+      if (response !== undefined) {
+        response = this.cache._lookupTransformResult(
+          response,
+          true // merge results should ALWAYS be an array
+        );
+      }
+      return response as RequestData;
     }
   }
 
@@ -520,24 +525,29 @@ export default class Store {
       this.source.transformBuilder
     );
     if (options?.fullResponse) {
-      const response = await this.source.update(transform, {
+      let response = await this.source.update(transform, {
         fullResponse: true
       });
-      const data = this.cache._lookupTransformResult(
-        response.data,
-        Array.isArray(transform.operations)
-      );
-      return {
-        ...response,
-        data
-      } as FullResponse<RequestData, undefined, RecordOperation>;
+      if (response.data !== undefined) {
+        const data = this.cache._lookupTransformResult(
+          response.data,
+          Array.isArray(transform.operations)
+        );
+        response = {
+          ...response,
+          data
+        };
+      }
+      return response as FullResponse<RequestData, unknown, RecordOperation>;
     } else {
-      const response = await this.source.update(transform);
-      const data = this.cache._lookupTransformResult(
-        response,
-        Array.isArray(transform.operations)
-      );
-      return data as RequestData;
+      let response = await this.source.update(transform);
+      if (response !== undefined) {
+        response = this.cache._lookupTransformResult(
+          response,
+          Array.isArray(transform.operations)
+        );
+      }
+      return response as RequestData;
     }
   }
 


### PR DESCRIPTION
Some coordination scenarios can result in `update` or `merge` (which calls `update` internally) to return `undefined`. For instance, if a blocking `beforeUpdate` listener applies the transform back to the source via `sync`, then `update` itself will return `undefined` because that transform will already have been logged.

Because of this, we need to check that a data response is not `undefined` before choosing to lookup results in their model form.