### PR TITLE
Allow Model#$getData to return undefined

### DIFF
--- a/addon/-private/model.ts
+++ b/addon/-private/model.ts
@@ -73,24 +73,19 @@ export default class Model {
   /**
    * @deprecated
    */
-  getData(): InitializedRecord {
+  getData(): InitializedRecord | undefined {
     deprecate(
       '`Model#getData` is deprecated to avoid potential conflicts with field names. Call `$getData` instead.'
     );
     return this.$getData();
   }
 
-  $getData(): InitializedRecord {
+  $getData(): InitializedRecord | undefined {
     assert(
       'Model must be connected to a store in order to call `$getData`',
       this._store !== undefined
     );
-    const data = this._store!.cache.getRecordData(this.type, this.id);
-    assert(
-      "`$getData` can not succeed because the record associated with the model no longer exists in its store's cache.",
-      data !== undefined
-    );
-    return data as InitializedRecord;
+    return this._store!.cache.getRecordData(this.type, this.id);
   }
 
   /**

--- a/tests/integration/model-test.ts
+++ b/tests/integration/model-test.ts
@@ -424,10 +424,19 @@ module('Integration - Model', function (hooks) {
     });
     let recordData = record.$getData();
     assert.equal(
-      recordData.attributes?.name,
+      recordData?.attributes?.name,
       'Jupiter',
       'returns record data (resource)'
     );
+  });
+
+  test('$getData returns undefined if record is not present in cache', async function (assert) {
+    const record = store.cache.lookup({
+      type: 'planet',
+      id: 'jupiter'
+    });
+    let recordData = record.$getData();
+    assert.strictEqual(recordData, undefined, 'returns undefined');
   });
 
   test('$getData fails when record has been removed from its store', async function (assert) {

--- a/tests/integration/store-test.ts
+++ b/tests/integration/store-test.ts
@@ -11,7 +11,7 @@ import { createStore } from 'dummy/tests/support/store';
 import { buildTransform } from '@orbit/data';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { RecordTransform } from '@orbit/records';
+import { InitializedRecord, RecordTransform } from '@orbit/records';
 
 module('Integration - Store', function (hooks) {
   setupTest(hooks);
@@ -553,7 +553,7 @@ module('Integration - Store', function (hooks) {
     assert.deepEqual(storeTransforms[0]?.operations, [
       {
         op: 'addRecord',
-        record: jupiterInStore.$getData()
+        record: jupiterInStore.$getData() as InitializedRecord
       }
     ]);
     store.off('transform', storeTransformed);


### PR DESCRIPTION
Fixes an overlooked use case in which a model instance could be looked up from the cache without having an underlying record in the orbit cache. This might happen, for example, when related records don't yet have a representation in the cache (just as identities in a relationship).

Fixes #353.