### PR TITLE
Enable fully synchronous updates to models and forked caches

### DIFF
--- a/addon/-private/cache.ts
+++ b/addon/-private/cache.ts
@@ -24,7 +24,8 @@ import {
   RecordQueryResult,
   RecordSchema,
   RecordTransformResult,
-  StandardRecordValidator
+  StandardRecordValidator,
+  UninitializedRecord
 } from '@orbit/records';
 import { StandardValidator, ValidatorForFn } from '@orbit/validators';
 import LiveQuery from './live-query';
@@ -37,6 +38,7 @@ import {
   ModelAwareTransformOrOperations,
   RecordIdentityOrModel
 } from './utils/model-aware-types';
+import { ModelFields } from './utils/model-fields';
 import recordIdentitySerializer from './utils/record-identity-serializer';
 
 const { assert, deprecate } = Orbit;
@@ -423,6 +425,48 @@ export default class Cache {
       (q) => q.findRecords(typeOrIdentities),
       options
     ) as Model[];
+  }
+
+  /**
+   * Adds a record
+   */
+  addRecord<RequestData extends RecordTransformResult<Model> = Model>(
+    properties: UninitializedRecord | ModelFields,
+    options?: DefaultRequestOptions<RecordCacheQueryOptions>
+  ): RequestData {
+    assert(
+      'Cache#addRecord does not support the `fullResponse` option. Call `cache.update(..., { fullResponse: true })` instead.',
+      options?.fullResponse === undefined
+    );
+    return this.update((t) => t.addRecord(properties), options);
+  }
+
+  /**
+   * Updates a record
+   */
+  updateRecord<RequestData extends RecordTransformResult<Model> = Model>(
+    properties: InitializedRecord | ModelFields,
+    options?: DefaultRequestOptions<RecordCacheQueryOptions>
+  ): RequestData {
+    assert(
+      'Cache#updateRecord does not support the `fullResponse` option. Call `cache.update(..., { fullResponse: true })` instead.',
+      options?.fullResponse === undefined
+    );
+    return this.update((t) => t.updateRecord(properties), options);
+  }
+
+  /**
+   * Removes a record
+   */
+  removeRecord(
+    identity: RecordIdentityOrModel,
+    options?: DefaultRequestOptions<RecordCacheQueryOptions>
+  ): void {
+    assert(
+      'Cache#removeRecord does not support the `fullResponse` option. Call `cache.update(..., { fullResponse: true })` instead.',
+      options?.fullResponse === undefined
+    );
+    this.update((t) => t.removeRecord(identity), options);
   }
 
   unload(identity: RecordIdentity): void {

--- a/addon/-private/fields/attr.ts
+++ b/addon/-private/fields/attr.ts
@@ -35,8 +35,8 @@ export default function attr(
   return (target: Model, property: string): TrackedAttr => {
     function get(this: Model): unknown {
       assert(
-        `The ${this.type} record has been removed from the store, so we cannot lookup the ${property} attr from the cache.`,
-        !this.$disconnected
+        `The ${this.type} record has been removed from its cache, so we cannot lookup the ${property} attribute.`,
+        !this.$isDisconnected
       );
 
       return getAttributeCache(this, property).value;
@@ -46,10 +46,7 @@ export default function attr(
       const oldValue = this.$getAttribute(property);
 
       if (value !== oldValue) {
-        this.$assertMutableFields();
-        this.$replaceAttribute(property, value).catch(() =>
-          getAttributeCache(this, property).notifyPropertyChange()
-        );
+        this.$replaceAttribute(property, value);
         getAttributeCache(this, property).value = value;
       }
     }

--- a/addon/-private/fields/has-many.ts
+++ b/addon/-private/fields/has-many.ts
@@ -47,8 +47,8 @@ export default function hasMany(
   return (target: Model, property: string): TrackedHasMany => {
     function get(this: Model): Model[] {
       assert(
-        `The ${this.type} record has been removed from the store, so we cannot lookup the ${property} hasMany from the cache.`,
-        !this.$disconnected
+        `The ${this.type} record has been removed from its cache, so we cannot lookup the ${property} hasMany relationship.`,
+        !this.$isDisconnected
       );
 
       return getHasManyCache(this, property).value as Model[];

--- a/addon/-private/fields/has-one.ts
+++ b/addon/-private/fields/has-one.ts
@@ -43,8 +43,8 @@ export default function hasOne(
   return (target: Model, property: string): TrackedHasOne => {
     function get(this: Model): Model | null {
       assert(
-        `The ${this.type} record has been removed from the store, so we cannot lookup the ${property} hasOne from the cache.`,
-        !this.$disconnected
+        `The ${this.type} record has been removed from its cache, so we cannot lookup the ${property} hasOne relationship.`,
+        !this.$isDisconnected
       );
 
       return getHasOneCache(this, property).value as Model | null;
@@ -54,10 +54,7 @@ export default function hasOne(
       const oldValue = this.$getRelatedRecord(property);
 
       if (value !== oldValue) {
-        this.$assertMutableFields();
-        this.$replaceRelatedRecord(property, value).catch(() =>
-          getHasOneCache(this, property).notifyPropertyChange()
-        );
+        this.$replaceRelatedRecord(property, value);
       }
     }
 

--- a/addon/-private/fields/key.ts
+++ b/addon/-private/fields/key.ts
@@ -16,8 +16,8 @@ export default function key(options: KeyDefinition = {}): any {
   return (target: Model, property: string): TrackedKey => {
     function get(this: Model): string {
       assert(
-        `The ${this.type} record has been removed from the store, so we cannot lookup the ${property} key from the cache.`,
-        !this.$disconnected
+        `The ${this.type} record has been removed from its cache, so we cannot lookup the ${property} key.`,
+        !this.$isDisconnected
       );
 
       return getKeyCache(this, property).value as string;
@@ -27,10 +27,7 @@ export default function key(options: KeyDefinition = {}): any {
       const oldValue = this.$getKey(property);
 
       if (value !== oldValue) {
-        this.$assertMutableFields();
-        this.$replaceKey(property, value).catch(() =>
-          getKeyCache(this, property).notifyPropertyChange()
-        );
+        this.$replaceKey(property, value);
         getKeyCache(this, property).value = value;
       }
     }

--- a/addon/-private/model-factory.ts
+++ b/addon/-private/model-factory.ts
@@ -2,7 +2,7 @@ import Orbit from '@orbit/core';
 import { getOwner } from '@ember/application';
 import { Dict } from '@orbit/utils';
 import { RecordIdentity, cloneRecordIdentity } from '@orbit/records';
-import Store from './store';
+import Cache from './cache';
 import Model, { ModelSettings } from './model';
 
 const { assert } = Orbit;
@@ -12,22 +12,20 @@ interface Factory {
 }
 
 export default class ModelFactory {
-  #store: Store;
+  #cache: Cache;
   #modelFactoryMap: Dict<Factory>;
-  #mutableModelFields: boolean;
 
-  constructor(store: Store, mutableModelFields: boolean) {
-    this.#store = store;
+  constructor(cache: Cache) {
+    this.#cache = cache;
     this.#modelFactoryMap = {};
-    this.#mutableModelFields = mutableModelFields;
   }
 
   create(identity: RecordIdentity): Model {
     const modelFactory = this.modelFactoryFor(identity.type);
+
     return modelFactory.create({
       identity: cloneRecordIdentity(identity),
-      store: this.#store,
-      mutableFields: this.#mutableModelFields
+      cache: this.#cache
     });
   }
 
@@ -35,7 +33,7 @@ export default class ModelFactory {
     let modelFactory = this.#modelFactoryMap[type];
 
     if (!modelFactory) {
-      let owner = getOwner(this.#store);
+      let owner = getOwner(this.#cache);
       let orbitConfig = owner.lookup('ember-orbit:config');
 
       modelFactory = owner.factoryFor(

--- a/addon/-private/store.ts
+++ b/addon/-private/store.ts
@@ -25,10 +25,9 @@ import {
   UninitializedRecord
 } from '@orbit/records';
 import { StandardValidator, ValidatorForFn } from '@orbit/validators';
-import Cache from './cache';
+import Cache, { CacheSettings } from './cache';
 import LiveQuery from './live-query';
 import Model from './model';
-import ModelFactory from './model-factory';
 import {
   ModelAwareQueryBuilder,
   ModelAwareQueryOrExpressions,
@@ -75,13 +74,12 @@ export default class Store {
     this.#source = settings.source;
     this.#base = settings.base;
 
-    this.#cache = new Cache({
-      sourceCache: this.source.cache,
-      modelFactory: new ModelFactory(
-        this,
-        this.forked || settings.mutableModelFields === true
-      )
-    });
+    const owner = getOwner(settings);
+    const cacheSettings: CacheSettings = {
+      sourceCache: this.source.cache
+    };
+    setOwner(cacheSettings, owner);
+    this.#cache = new Cache(cacheSettings);
 
     if (this.#base) {
       associateDestroyableChild(this.#base, this);

--- a/addon/-private/store.ts
+++ b/addon/-private/store.ts
@@ -552,11 +552,25 @@ export default class Store {
   }
 
   transformsSince(transformId: string): RecordTransform[] {
-    return this.source.transformsSince(transformId);
+    deprecate(
+      '`Store#transformsSince` is deprecated. Call `getTransformsSince` instead.'
+    );
+    return this.getTransformsSince(transformId);
+  }
+
+  getTransformsSince(transformId: string): RecordTransform[] {
+    return this.source.getTransformsSince(transformId);
   }
 
   allTransforms(): RecordTransform[] {
-    return this.source.allTransforms();
+    deprecate(
+      '`Store#allTransforms` is deprecated. Call `getAllTransforms` instead.'
+    );
+    return this.getAllTransforms();
+  }
+
+  getAllTransforms(): RecordTransform[] {
+    return this.source.getAllTransforms();
   }
 
   getTransform(transformId: string): RecordTransform {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@orbit/core": "^0.17.0-beta.20",
     "@orbit/data": "^0.17.0-beta.20",
     "@orbit/identity-map": "^0.17.0-beta.22",
-    "@orbit/memory": "^0.17.0-beta.23",
+    "@orbit/memory": "^0.17.0-beta.24",
     "@orbit/records": "^0.17.0-beta.22",
     "@orbit/utils": "^0.17.0-beta.19",
     "@orbit/validators": "^0.17.0-beta.22",

--- a/tests/integration/cache-test.ts
+++ b/tests/integration/cache-test.ts
@@ -97,6 +97,33 @@ module('Integration - Cache', function (hooks) {
     assert.strictEqual(jupiter.name, 'Jupiter');
   });
 
+  test('#addRecord', async function (assert) {
+    const earth = cache.addRecord<Planet>({ type: 'planet', name: 'Earth' });
+    assert.strictEqual(cache.lookup(earth), earth);
+    assert.strictEqual(earth.name, 'Earth');
+  });
+
+  test('#updateRecord', async function (assert) {
+    const earth = cache.addRecord<Planet>({ type: 'planet', name: 'Earth' });
+    cache.updateRecord({
+      type: 'planet',
+      id: earth.id,
+      name: 'Mother Earth'
+    });
+    assert.strictEqual(cache.lookup(earth), earth);
+    assert.strictEqual(earth.name, 'Mother Earth');
+  });
+
+  test('#removeRecord', async function (assert) {
+    const earth = cache.addRecord<Planet>({ type: 'planet', name: 'Earth' });
+    cache.removeRecord(earth);
+    assert.ok(earth.$isDisconnected, 'model is disconnected');
+    assert.notOk(
+      cache.includesRecord('planet', earth.id),
+      'cache does not include record'
+    );
+  });
+
   test('#query - record', async function (assert) {
     const earth = await store.addRecord({ type: 'planet', name: 'Earth' });
     await store.addRecord({ type: 'planet', name: 'Jupiter' });

--- a/tests/integration/store-test.ts
+++ b/tests/integration/store-test.ts
@@ -202,7 +202,7 @@ module('Integration - Store', function (hooks) {
     ]);
   });
 
-  test('#transformsSince - returns all transforms since a specified transformId', async function (assert) {
+  test('#getTransformsSince - returns all transforms since a specified transformId', async function (assert) {
     const recordA = {
       id: 'jupiter',
       type: 'planet',
@@ -229,13 +229,13 @@ module('Integration - Store', function (hooks) {
     await store.sync(addRecordCTransform);
 
     assert.deepEqual(
-      store.transformsSince(addRecordATransform.id),
+      store.getTransformsSince(addRecordATransform.id),
       [addRecordBTransform, addRecordCTransform],
       'returns transforms since the specified transform'
     );
   });
 
-  test('#allTransforms - returns all tracked transforms', async function (assert) {
+  test('#getAllTransforms - returns all tracked transforms', async function (assert) {
     const recordA = {
       id: 'jupiter',
       type: 'planet',
@@ -262,7 +262,7 @@ module('Integration - Store', function (hooks) {
     await store.sync(addRecordCTransform);
 
     assert.deepEqual(
-      store.allTransforms(),
+      store.getAllTransforms(),
       [addRecordATransform, addRecordBTransform, addRecordCTransform],
       'tracks transforms in correct order'
     );
@@ -703,7 +703,7 @@ module('Integration - Store', function (hooks) {
 
     fork.rebase();
 
-    assert.deepEqual(fork.allTransforms(), [addRecordD, addRecordE]);
+    assert.deepEqual(fork.getAllTransforms(), [addRecordD, addRecordE]);
 
     assert.deepEqual(fork.cache.findRecords('planet').length, 5);
     assert.ok(fork.cache.includesRecord(recordA.type, recordA.id));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1316,22 +1316,22 @@
   resolved "https://registry.yarnpkg.com/@orbit/immutable/-/immutable-0.17.0-beta.14.tgz#092f85409b82bafda84eaa2280478805ba904ab6"
   integrity sha512-8RAXijo9emE4+3S6n8BT8lsQFnTE8O+NlpnBp9TbMjKeEkZCv3lQNgN+M7iJrYfTMRnhqKPevl2EFyAdqPbsOg==
 
-"@orbit/memory@^0.17.0-beta.23":
-  version "0.17.0-beta.23"
-  resolved "https://registry.yarnpkg.com/@orbit/memory/-/memory-0.17.0-beta.23.tgz#62d56231b407c850ae5b3a99d69ef90baf1193b4"
-  integrity sha512-c1cqVzVu4MwXNvpAyS1uNJ7EtMG5lSX0QLrQy6lSJncrjrOSS5+QQu4D3o0EmlRIVqe0TJA56u+Lj5MAJqBolQ==
+"@orbit/memory@^0.17.0-beta.24":
+  version "0.17.0-beta.24"
+  resolved "https://registry.yarnpkg.com/@orbit/memory/-/memory-0.17.0-beta.24.tgz#f71c924d582f54997ff80eb6b24a131a675a1b94"
+  integrity sha512-n7C0e9MW4w8j22r1/oVkWVa+cMs0a2t45DHhtpwHnMjhRE2rRZYxawPkmgAGetJ9Q+sgzNYZRVunLHJQG8+kug==
   dependencies:
     "@orbit/core" "^0.17.0-beta.20"
     "@orbit/data" "^0.17.0-beta.20"
     "@orbit/immutable" "^0.17.0-beta.14"
-    "@orbit/record-cache" "^0.17.0-beta.23"
+    "@orbit/record-cache" "^0.17.0-beta.24"
     "@orbit/records" "^0.17.0-beta.22"
     "@orbit/utils" "^0.17.0-beta.19"
 
-"@orbit/record-cache@^0.17.0-beta.23":
-  version "0.17.0-beta.23"
-  resolved "https://registry.yarnpkg.com/@orbit/record-cache/-/record-cache-0.17.0-beta.23.tgz#09155de8101c9dff0d6d50c9bd000987ec096b98"
-  integrity sha512-pW+eVvqbaVdflmI57BAZsYUIX4VEG51xVq6S0qbwS4IPDFl+o1zt2QweS/r4jYALq+mptB17Lyl56cHqX9MAfQ==
+"@orbit/record-cache@^0.17.0-beta.24":
+  version "0.17.0-beta.24"
+  resolved "https://registry.yarnpkg.com/@orbit/record-cache/-/record-cache-0.17.0-beta.24.tgz#ae71dbbb81d342e5233e6271b96edb1195eac9ac"
+  integrity sha512-EhYW5Aw6qabHpm4C7TsFLjz6RIXk9sH2G89rBSZN32CBfKoJYiuUrg4LFaxkCn+C2BEcueQNCfzhk1X4zKMU6w==
   dependencies:
     "@orbit/core" "^0.17.0-beta.20"
     "@orbit/data" "^0.17.0-beta.20"


### PR DESCRIPTION
This is a significant update to ember-orbit, made possible by the underlying work in `@orbit/memory` [v0.17.0-beta.24](https://github.com/orbitjs/orbit/releases/tag/v0.17.0-beta.24).

## Synchronous updates via models

Now that a `MemoryCache` can track all operations applied to it, and it will do so by default when it is forked, we can finally switch ember-orbit models to perform all updates through their associated `Cache` instead of `Store`. And since memory updates are all synchronous, all the update-related methods on `Model` can be made synchronous as well.

As part of this refactor, models now store a reference to their parent `Cache` and no longer need a reference to a `Store`.

## Allowing / preventing updates to caches

By default, only forked caches support updates. If you want to allow updates on non-forked caches, you can override the `allowUpdates` property. This property on a cache will also need to be overridden if you would like to allow updates to any of its associated models, since they all flow through `Cache#update`. Note that this is prevented by default for a reason - updates to non-forked caches will be ephemeral and only last the lifetime of the cache. Typically, it's preferable to update your sources directly or to follow the fork / update cache / merge pattern. 

## Some additional `Cache` methods

Now that direct cache updating is truly viable, some convenience methods have been added:

* `addRecord`
* `updateRecord`
* `removeRecord`

These sync methods are all internally based on `Cache#update`.

## New patterns

To drive home the new use cases made possible here, let's take a look at a simple example:

```typescript
// fork a store (sync)
let fork = store.fork();

// make some (sync) edits to the cache, direct or through models
let earth = fork.cache.addRecord({ type: 'planet', id: 'earth' });
earth.name = 'Earth';

// (async) merge of fork
let response = await store.merge(fork); // response = [earth];
```

---

Closes #348