### PR TITLE
Narrow Model.$isDisconnected tracking

### DIFF
--- a/tests/integration/rendering-test.ts
+++ b/tests/integration/rendering-test.ts
@@ -18,6 +18,28 @@ module('Rendering', function (hooks) {
     cache = store.cache;
   });
 
+  test('connected / disconnected models', async function (assert) {
+    const jupiter = cache.addRecord({ type: 'planet', name: 'Jupiter' });
+    this.set('planet', jupiter);
+
+    await render(hbs`
+      <h1>
+        {{#if this.planet.$isDisconnected}}
+          Disconnected
+        {{else}}
+          Connected
+        {{/if}}
+      </h1>
+    `);
+
+    assert.dom('h1').includesText('Connected');
+
+    jupiter.$disconnect();
+    await settled();
+
+    assert.dom('h1').includesText('Disconnected');
+  });
+
   test('update relationship synchronously via cache', async function (assert) {
     const jupiter = cache.addRecord({ type: 'planet', name: 'Jupiter' });
     this.set('planet', jupiter);


### PR DESCRIPTION
Instead of directly tracking a model's `_cache`, track a new protected property, `_isDisconnected`, in order to determine when a model has been disconnected from its cache.

This fixes a problem, reported in https://github.com/orbitjs/ember-orbit/issues/359, in which rendered static resultsets would immediately be invalidated when a member was removed.

Note that, with this change, it's still possible to make a model's rendering conditional upon its `$isDisconnected` property.

Closes #359