### PR TITLE
Provide `schemaVersion` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,7 @@ module.exports = function (environment) {
 
     // Default Orbit settings (any of which can be overridden)
     orbit: {
+      schemaVersion: undefined,
       types: {
         bucket: 'data-bucket',
         model: 'data-model',
@@ -622,6 +623,12 @@ module.exports = function (environment) {
   return ENV;
 };
 ```
+
+Note that `schemaVersion` should be set if you're using any Orbit sources, such
+as `IndexedDBSource`, that track schema version. By default, Orbit's schema
+version will start at `1`. This value should be bumped to a a higher number with
+each significant change that requires a schema migration. Migrations themselves
+must be handled in each individual source.
 
 ## Contributing to EO
 

--- a/addon/-private/factories/schema-factory.ts
+++ b/addon/-private/factories/schema-factory.ts
@@ -19,12 +19,13 @@ type SchemaInjections = { modelNames?: string[] } & RecordSchemaSettings;
 
 export default {
   create(injections: SchemaInjections = {}): RecordSchema {
-    if (!injections.models) {
-      const app = getOwner(injections);
+    const app = getOwner(injections);
+    const orbitConfig = app.lookup('ember-orbit:config');
+
+    if (injections.models === undefined) {
       const modelSchemas: Dict<ModelDefinition> = {};
 
-      let orbitConfig = app.lookup('ember-orbit:config');
-      let modelNames =
+      const modelNames =
         injections.modelNames ??
         getRegisteredModels(
           app.base.modulePrefix,
@@ -45,6 +46,8 @@ export default {
 
       injections.models = modelSchemas;
     }
+
+    injections.version ??= orbitConfig.schemaVersion;
 
     return new RecordSchema(injections);
   }

--- a/tests/integration/config-test.ts
+++ b/tests/integration/config-test.ts
@@ -14,6 +14,7 @@ module('Integration - Config', function (hooks) {
       'config:environment',
       {
         orbit: {
+          schemaVersion: 2,
           types: {
             bucket: 'orbit-bucket',
             model: 'orbit-model',
@@ -48,6 +49,7 @@ module('Integration - Config', function (hooks) {
     const normalizer = this.owner.lookup('service:orbit-normalizer');
     const validatorFor = this.owner.lookup('service:orbit-validator');
 
+    assert.equal(schema.version, 2, 'schema version matches configuration');
     assert.equal(
       this.owner.lookup('service:orbit-store'),
       store,


### PR DESCRIPTION
`schemaVersion` should be set if you're using any Orbit sources, such as `IndexedDBSource`, that track schema version. By default, Orbit's schema version will start at `1`. This value should be bumped to a a higher number with each significant change that requires a schema migration. Migrations themselves must be handled in each individual source.