### PR TITLE
Correct Model field checking of cache disconnection

### DIFF
--- a/addon/-private/fields/attr.ts
+++ b/addon/-private/fields/attr.ts
@@ -36,7 +36,7 @@ export default function attr(
     function get(this: Model): unknown {
       assert(
         `The ${this.type} record has been removed from its cache, so we cannot lookup the ${property} attribute.`,
-        !this.$isDisconnected
+        this._cache !== undefined
       );
 
       return getAttributeCache(this, property).value;

--- a/addon/-private/fields/has-many.ts
+++ b/addon/-private/fields/has-many.ts
@@ -48,7 +48,7 @@ export default function hasMany(
     function get(this: Model): Model[] {
       assert(
         `The ${this.type} record has been removed from its cache, so we cannot lookup the ${property} hasMany relationship.`,
-        !this.$isDisconnected
+        this._cache !== undefined
       );
 
       return getHasManyCache(this, property).value as Model[];

--- a/addon/-private/fields/has-one.ts
+++ b/addon/-private/fields/has-one.ts
@@ -44,7 +44,7 @@ export default function hasOne(
     function get(this: Model): Model | null {
       assert(
         `The ${this.type} record has been removed from its cache, so we cannot lookup the ${property} hasOne relationship.`,
-        !this.$isDisconnected
+        this._cache !== undefined
       );
 
       return getHasOneCache(this, property).value as Model | null;

--- a/addon/-private/fields/key.ts
+++ b/addon/-private/fields/key.ts
@@ -17,7 +17,7 @@ export default function key(options: KeyDefinition = {}): any {
     function get(this: Model): string {
       assert(
         `The ${this.type} record has been removed from its cache, so we cannot lookup the ${property} key.`,
-        !this.$isDisconnected
+        this._cache !== undefined
       );
 
       return getKeyCache(this, property).value as string;

--- a/addon/-private/model.ts
+++ b/addon/-private/model.ts
@@ -28,7 +28,7 @@ export interface ModelSettings {
 }
 export default class Model {
   @tracked protected _isDisconnected = false;
-  #cache?: Cache;
+  protected _cache?: Cache;
   #identity: RecordIdentity;
 
   constructor(settings: ModelSettings) {
@@ -36,7 +36,7 @@ export default class Model {
 
     assert('Model must be initialized with a cache', cache !== undefined);
 
-    this.#cache = cache;
+    this._cache = cache;
     this.#identity = identity;
     associateDestroyableChild(cache, this);
     registerDestructor(this, (record) => cache.unload(record));
@@ -362,7 +362,7 @@ export default class Model {
   }
 
   $disconnect(): void {
-    this.#cache = undefined;
+    this._cache = undefined;
     this._isDisconnected = true;
   }
 
@@ -395,11 +395,11 @@ export default class Model {
   }
 
   get $cache(): Cache {
-    if (!this.#cache) {
+    if (this._cache === undefined) {
       throw new Assertion('Record has been disconnected from its cache.');
     }
 
-    return this.#cache;
+    return this._cache;
   }
 
   static get definition(): ModelDefinition {

--- a/tests/integration/rendering-test.ts
+++ b/tests/integration/rendering-test.ts
@@ -40,6 +40,24 @@ module('Rendering', function (hooks) {
     assert.dom('h1').includesText('Disconnected');
   });
 
+  test('persistent properties, event when models are disconnected', async function (assert) {
+    const jupiter = cache.addRecord({ type: 'planet', name: 'Jupiter' });
+    this.set('planet', jupiter);
+
+    await render(hbs`
+      <h1>
+        {{this.planet.name}}
+      </h1>
+    `);
+
+    assert.dom('h1').includesText('Jupiter');
+
+    jupiter.$disconnect();
+    await settled();
+
+    assert.dom('h1').includesText('Jupiter');
+  });
+
   test('update relationship synchronously via cache', async function (assert) {
     const jupiter = cache.addRecord({ type: 'planet', name: 'Jupiter' });
     this.set('planet', jupiter);


### PR DESCRIPTION
Fixes a bug that was introduced in which a model's tracked property, `$isDisconnected`, was checked to determine cache disconnection before fetching field values. This check is now made against the model's `_cache`, which is no longer tracked. This allows static resultsets to persist, even after disconnection.

Fixes #359