### PR TITLE
Expose $store on Model

### DIFF
--- a/addon/-private/cache.ts
+++ b/addon/-private/cache.ts
@@ -29,6 +29,7 @@ import {
   UninitializedRecord
 } from '@orbit/records';
 import { StandardValidator, ValidatorForFn } from '@orbit/validators';
+import type Store from './store';
 import LiveQuery from './live-query';
 import Model from './model';
 import ModelFactory from './model-factory';
@@ -46,6 +47,7 @@ const { assert, deprecate } = Orbit;
 
 export interface CacheSettings {
   sourceCache: MemoryCache;
+  store: Store;
 }
 
 export default class Cache {
@@ -55,6 +57,7 @@ export default class Cache {
     ModelAwareQueryBuilder,
     ModelAwareTransformBuilder
   >;
+  #store: Store;
   #modelFactory: ModelFactory;
   allowUpdates: boolean;
 
@@ -67,6 +70,7 @@ export default class Cache {
     setOwner(this, owner);
 
     this.#sourceCache = settings.sourceCache;
+    this.#store = settings.store;
     this.#modelFactory = new ModelFactory(this);
     this.allowUpdates = this.#sourceCache.base !== undefined;
 
@@ -83,6 +87,10 @@ export default class Cache {
 
   get sourceCache(): MemoryCache {
     return this.#sourceCache;
+  }
+
+  get store(): Store {
+    return this.#store;
   }
 
   get keyMap(): RecordKeyMap | undefined {

--- a/addon/-private/model.ts
+++ b/addon/-private/model.ts
@@ -17,6 +17,7 @@ import {
 import { tracked } from '@glimmer/tracking';
 
 import Cache from './cache';
+import type Store from './store';
 import { getModelDefinition } from './utils/model-definition';
 import { notifyPropertyChange } from './utils/property-cache';
 
@@ -400,6 +401,10 @@ export default class Model {
     }
 
     return this._cache;
+  }
+
+  get $store(): Store {
+    return this.$cache.store;
   }
 
   static get definition(): ModelDefinition {

--- a/addon/-private/store.ts
+++ b/addon/-private/store.ts
@@ -76,7 +76,8 @@ export default class Store {
 
     const owner = getOwner(settings);
     const cacheSettings: CacheSettings = {
-      sourceCache: this.source.cache
+      sourceCache: this.source.cache,
+      store: this
     };
     setOwner(cacheSettings, owner);
     this.#cache = new Cache(cacheSettings);


### PR DESCRIPTION
The recent changes (thanks!) to cache change tracking replaced `Model`'s `$store` with `$cache`.

But `$cache` is not fully-featured in the same way that `$store` is. For example, it doesn't implement `fork` and `merge`. `$cache.sourceCache` does implement these methods, but at the orbit layer, not the ember-orbit layer, meaning we don't get back a new `Cache` that can give us `Model` instances.

This PR re-exposes `$store` on `Model` (and also adds `store` on `Cache`). This makes is again possible to take an existing Model and fork it on demand, and then merge back into its original source.

An alternative solution here would be to implement fork & merge on ember-orbit's `Cache`. But I'm not 100% clear if those are intended to have the same semantics as forking and merging of underlying sources. In my use case, I definitely want the merge to not only merge into the base cache, but merge all the way into the base source.

The thing I'm trying to keep working is this pair of utility methods that are used throughout my app to accept an existing model and establish a fork of it that can later be merged:

```js
export function fork(model) {
  let store = model.$store;
  let forkedStore = store.fork();
  return forkedStore.cache.findRecord(model);
}

export async function merge(model) {
  let { $store } = model;
  if (!$store.forked) {
    throw new Error(`tried to save a model that is not in a forked store`);
  }
  let result = await $store.base.merge($store);
  return result[0];
}
```