### PR TITLE
Expose store on Cache

### DIFF
--- a/addon/-private/cache.ts
+++ b/addon/-private/cache.ts
@@ -47,7 +47,7 @@ const { assert, deprecate } = Orbit;
 
 export interface CacheSettings {
   sourceCache: MemoryCache;
-  store: Store;
+  store?: Store;
 }
 
 export default class Cache {
@@ -57,7 +57,7 @@ export default class Cache {
     ModelAwareQueryBuilder,
     ModelAwareTransformBuilder
   >;
-  #store: Store;
+  #store?: Store;
   #modelFactory: ModelFactory;
   allowUpdates: boolean;
 
@@ -89,7 +89,7 @@ export default class Cache {
     return this.#sourceCache;
   }
 
-  get store(): Store {
+  get store(): Store | undefined {
     return this.#store;
   }
 

--- a/addon/-private/cache.ts
+++ b/addon/-private/cache.ts
@@ -29,6 +29,7 @@ import {
   UninitializedRecord
 } from '@orbit/records';
 import { StandardValidator, ValidatorForFn } from '@orbit/validators';
+import type Store from './store';
 import LiveQuery from './live-query';
 import Model from './model';
 import ModelFactory from './model-factory';
@@ -46,6 +47,7 @@ const { assert, deprecate } = Orbit;
 
 export interface CacheSettings {
   sourceCache: MemoryCache;
+  store: Store;
 }
 
 export default class Cache {
@@ -55,6 +57,7 @@ export default class Cache {
     ModelAwareQueryBuilder,
     ModelAwareTransformBuilder
   >;
+  #store: Store;
   #modelFactory: ModelFactory;
   allowUpdates: boolean;
 
@@ -67,6 +70,7 @@ export default class Cache {
     setOwner(this, owner);
 
     this.#sourceCache = settings.sourceCache;
+    this.#store = settings.store;
     this.#modelFactory = new ModelFactory(this);
     this.allowUpdates = this.#sourceCache.base !== undefined;
 
@@ -83,6 +87,10 @@ export default class Cache {
 
   get sourceCache(): MemoryCache {
     return this.#sourceCache;
+  }
+
+  get store(): Store {
+    return this.#store;
   }
 
   get keyMap(): RecordKeyMap | undefined {

--- a/addon/-private/model.ts
+++ b/addon/-private/model.ts
@@ -17,7 +17,6 @@ import {
 import { tracked } from '@glimmer/tracking';
 
 import Cache from './cache';
-import type Store from './store';
 import { getModelDefinition } from './utils/model-definition';
 import { notifyPropertyChange } from './utils/property-cache';
 
@@ -401,10 +400,6 @@ export default class Model {
     }
 
     return this._cache;
-  }
-
-  get $store(): Store {
-    return this.$cache.store;
   }
 
   static get definition(): ModelDefinition {

--- a/addon/-private/model.ts
+++ b/addon/-private/model.ts
@@ -17,6 +17,7 @@ import {
 import { tracked } from '@glimmer/tracking';
 
 import Cache from './cache';
+import type Store from './store';
 import { getModelDefinition } from './utils/model-definition';
 import { notifyPropertyChange } from './utils/property-cache';
 
@@ -400,6 +401,10 @@ export default class Model {
     }
 
     return this._cache;
+  }
+
+  get $store(): Store {
+    return this.$cache.store;
   }
 
   static get definition(): ModelDefinition {

--- a/addon/-private/store.ts
+++ b/addon/-private/store.ts
@@ -75,7 +75,8 @@ export default class Store {
 
     const owner = getOwner(settings);
     const cacheSettings: CacheSettings = {
-      sourceCache: this.source.cache
+      sourceCache: this.source.cache,
+      store: this
     };
     setOwner(cacheSettings, owner);
     this.#cache = new Cache(cacheSettings);

--- a/tests/integration/cache-test.ts
+++ b/tests/integration/cache-test.ts
@@ -20,6 +20,10 @@ module('Integration - Cache', function (hooks) {
     cache = store.cache;
   });
 
+  test('exposes store', function (assert) {
+    assert.strictEqual(cache.store, store);
+  });
+
   test('exposes properties from underlying MemoryCache', function (assert) {
     assert.strictEqual(cache.sourceCache, store.source.cache);
     assert.strictEqual(cache.keyMap, store.source.keyMap);


### PR DESCRIPTION
Based on #366 and the subsequent changes requested.

This allows for `store` to be accessed from a `Cache`, but allows for this property to be undefined. This will be the case when ember-orbit supports cache-based forking and merging that mirrors the base capabilities in orbit.