### PR TITLE
Introduce main bucket service to allow for bucket injections

### DIFF
--- a/addon/-private/utils/standard-injections.ts
+++ b/addon/-private/utils/standard-injections.ts
@@ -10,6 +10,9 @@ export function applyStandardSourceInjections(
   if (!orbitConfig.skipSchemaService) {
     injections.schema = app.lookup(`service:${orbitConfig.services.schema}`);
   }
+  if (!orbitConfig.skipBucketService) {
+    injections.bucket = app.lookup(`service:${orbitConfig.services.bucket}`);
+  }
   if (!orbitConfig.skipKeyMapService) {
     injections.keyMap = app.lookup(`service:${orbitConfig.services.keyMap}`);
   }

--- a/addon/initializers/ember-orbit-config.ts
+++ b/addon/initializers/ember-orbit-config.ts
@@ -16,6 +16,7 @@ export interface OrbitConfig {
   };
   services: {
     store: string;
+    bucket: string;
     coordinator: string;
     schema: string;
     keyMap: string;
@@ -23,6 +24,7 @@ export interface OrbitConfig {
     validator: string;
   };
   skipStoreService: boolean;
+  skipBucketService: boolean;
   skipCoordinatorService: boolean;
   skipSchemaService: boolean;
   skipKeyMapService: boolean;
@@ -45,6 +47,7 @@ export const DEFAULT_ORBIT_CONFIG: OrbitConfig = {
   },
   services: {
     store: 'store',
+    bucket: 'data-bucket',
     coordinator: 'data-coordinator',
     schema: 'data-schema',
     keyMap: 'data-key-map',
@@ -52,6 +55,7 @@ export const DEFAULT_ORBIT_CONFIG: OrbitConfig = {
     validator: 'data-validator'
   },
   skipStoreService: false,
+  skipBucketService: false,
   skipCoordinatorService: false,
   skipSchemaService: false,
   skipKeyMapService: false,

--- a/addon/initializers/ember-orbit-services.ts
+++ b/addon/initializers/ember-orbit-services.ts
@@ -12,8 +12,9 @@ import ValidatorFactory from '../-private/factories/validator-factory';
 const { deprecate } = Orbit;
 
 export function initialize(application: Application) {
-  let orbitConfig: OrbitConfig =
-    application.resolveRegistration('ember-orbit:config') ?? {};
+  let orbitConfig: OrbitConfig = application.resolveRegistration(
+    'ember-orbit:config'
+  );
 
   if (!orbitConfig.skipKeyMapService) {
     // Register a keyMap service

--- a/blueprints/data-bucket/files/__root__/initializers/__initializer__.js
+++ b/blueprints/data-bucket/files/__root__/initializers/__initializer__.js
@@ -1,30 +1,14 @@
 import BucketFactory from '../<%= bucketsCollection %>/<%= dasherizedModuleName %>';
 
 export function initialize(application) {
-  const config = application.resolveRegistration('ember-orbit:config') || {};
+  const orbitConfig = application.resolveRegistration('ember-orbit:config');
 
-  const bucketService = '<%= serviceName %>';
-
-  // Register bucket service
-  application.register(`service:${bucketService}`, BucketFactory);
-
-  // Inject bucket into all sources
-  if (config.types) {
-    application.inject(
-      config.types.source,
-      'bucket',
-      `service:${bucketService}`
-    );
-  }
-
-  // Inject bucket into keyMap (if one is present)
-  if (config.services && !config.skipKeyMap) {
-    application.inject(
-      `service:${config.services.keyMap}`,
-      'bucket',
-      `service:${bucketService}`
-    );
-  }
+  // Register this bucket as the main bucket service so that it can be injected
+  // into sources via `applyStandardSourceInjections`.
+  //
+  // IMPORTANT: If your app has more than one bucket, only register one as the
+  // main bucket service.
+  application.register(`service:${orbitConfig.services.bucket}`, BucketFactory);
 }
 
 export default {


### PR DESCRIPTION
By registering a bucket with a standard service name, the `applyStandardSourceInjections` utility can inject it into sources. The standard bucket service name can be configured as an orbit option, just like the other standard orbit services.

A note has been added to the bucket initializer blueprint to clarify that only one bucket should be registered as the standard bucket service.

This eliminates the last usage of implicit injections in ember-orbit.

It's a breaking change because previously created bucket initializers should be revisited to remove implicit injections and replace them with the service registration.

Closes #379