### PR TITLE
Introduce `content` as a deprecated synonym for `value` on LiveQuery

### DIFF
--- a/addon/-private/live-query.ts
+++ b/addon/-private/live-query.ts
@@ -13,7 +13,7 @@ import { createCache, getValue } from '@glimmer/tracking/primitives/cache';
 import Cache from './cache';
 import { Model } from 'ember-orbit';
 
-const { assert } = Orbit;
+const { assert, deprecate } = Orbit;
 
 export interface LiveQuerySettings {
   liveQuery: SyncLiveQuery;
@@ -50,6 +50,16 @@ export default class LiveQuery implements Iterable<Model> {
 
   get query(): RecordQuery {
     return this.#query;
+  }
+
+  /**
+   * @deprecated
+   */
+  get content(): RecordQueryResult<Model> {
+    deprecate(
+      'LiveQuery#content is deprecated. Access LiveQuery#value instead.'
+    );
+    return this.value;
   }
 
   get value(): RecordQueryResult<Model> {

--- a/tests/integration/rendering-test.ts
+++ b/tests/integration/rendering-test.ts
@@ -148,13 +148,30 @@ module('Rendering', function (hooks) {
     assert.dom('.planets-count').includesText('2');
   });
 
-  test('liveQuery record', async function (assert) {
+  test('liveQuery record - accessed via `value` of LiveQuery', async function (assert) {
     const planet = cache.liveQuery((q) =>
       q.findRecord({ type: 'planet', id: '1' })
     );
     this.set('planet', planet);
 
     await render(hbs`<Planet @planet={{this.planet.value}} />`);
+
+    assert.dom('.planet').hasNoText();
+
+    await store.addRecord({ type: 'planet', id: '1', name: 'Jupiter' });
+    assert.dom('.planet').includesText('Jupiter');
+
+    await store.removeRecord({ type: 'planet', id: '1' });
+    assert.dom('.planet').hasNoText('Earth');
+  });
+
+  test('liveQuery record - accessed via deprecated `content` of LiveQuery', async function (assert) {
+    const planet = cache.liveQuery((q) =>
+      q.findRecord({ type: 'planet', id: '1' })
+    );
+    this.set('planet', planet);
+
+    await render(hbs`<Planet @planet={{this.planet.content}} />`);
 
     assert.dom('.planet').hasNoText();
 


### PR DESCRIPTION
Provides a deprecated upgrade path for v0.16 apps expecting ArrayProxy results.