### PR TITLE
Introduce Store#updateRecordFields

### DIFF
--- a/addon/-private/store.ts
+++ b/addon/-private/store.ts
@@ -350,6 +350,32 @@ export default class Store {
   }
 
   /**
+   * Updates a record's fields. Distinct from updateRecord in that updateRecordFields takes a record identity as a separate argument
+   * from the fields to update.
+   */
+  async updateRecordFields<
+    RequestData extends RecordTransformResult<Model> = Model
+  >(
+    identity: RecordIdentityOrModel,
+    fields: Partial<InitializedRecord> | Partial<ModelFields>,
+    options?: DefaultRequestOptions<RecordCacheQueryOptions>
+  ): Promise<RequestData> {
+    assert(
+      'Store#updateRecordFields does not support the `fullResponse` option. Call `store.update(..., { fullResponse: true })` instead.',
+      options?.fullResponse === undefined
+    );
+    const { type, id } = this.transformBuilder.$normalizeRecordIdentity(
+      identity
+    );
+    const properties = {
+      type,
+      id,
+      ...fields
+    };
+    return await this.update((t) => t.updateRecord(properties), options);
+  }
+
+  /**
    * Removes a record
    */
   async removeRecord(

--- a/tests/integration/store-test.ts
+++ b/tests/integration/store-test.ts
@@ -127,6 +127,51 @@ module('Integration - Store', function (hooks) {
     assert.strictEqual(record, earth);
   });
 
+  test('#updateRecord - can update a record identified by id', async function (assert) {
+    const earth = await store.addRecord<Planet>({
+      type: 'planet',
+      name: 'Earth',
+      remoteId: 'p01'
+    });
+    await store.updateRecord({
+      type: 'planet',
+      id: earth.id,
+      name: 'Mother Earth'
+    });
+    assert.strictEqual(earth.name, 'Mother Earth');
+  });
+
+  test("#updateRecordFields - can update a record's fields", async function (assert) {
+    const earth = await store.addRecord<Planet>({
+      type: 'planet',
+      name: 'Earth',
+      remoteId: 'p01'
+    });
+    await store.updateRecordFields(earth, {
+      name: 'Mother Earth'
+    });
+    assert.strictEqual(earth.name, 'Mother Earth');
+  });
+
+  test('#updateRecordFields - can update a record identified by key', async function (assert) {
+    const earth = await store.addRecord<Planet>({
+      type: 'planet',
+      name: 'Earth',
+      remoteId: 'p01'
+    });
+    await store.updateRecordFields(
+      {
+        type: 'planet',
+        key: 'remoteId',
+        value: 'p01'
+      },
+      {
+        name: 'Mother Earth'
+      }
+    );
+    assert.strictEqual(earth.name, 'Mother Earth');
+  });
+
   test('#removeRecord - when passed a record, it should serialize its identity in a `removeRecord` op', async function (assert) {
     assert.expect(2);
 


### PR DESCRIPTION
This method is distinct from `updateRecord` in that `updateRecordFields` takes a record identity as a separate argument from the fields to update.