### PR TITLE
Skip all validations by default when skipValidatorService = true

### DIFF
--- a/addon/-private/utils/standard-injections.ts
+++ b/addon/-private/utils/standard-injections.ts
@@ -21,7 +21,9 @@ export function applyStandardSourceInjections(
       `service:${orbitConfig.services.normalizer}`
     );
   }
-  if (!orbitConfig.skipValidatorService) {
+  if (orbitConfig.skipValidatorService) {
+    injections.autoValidate = false;
+  } else {
     injections.validatorFor = app.lookup(
       `service:${orbitConfig.services.validator}`
     );


### PR DESCRIPTION
The `skipValidatorService` option can thus be used to either:
- create a `validatorFor` service shared by all sources, or
- skip validations entirely within all sources (by setting `autoValidate = false`)