### PR TITLE
Fix isStandardRecord check

### DIFF
--- a/addon/-private/utils/model-aware-normalizer.ts
+++ b/addon/-private/utils/model-aware-normalizer.ts
@@ -22,9 +22,9 @@ export function isStandardRecord(
   data: UninitializedRecord | ModelFields
 ): data is UninitializedRecord {
   return (
-    typeof data.attributes === 'object' ||
-    typeof data.keys === 'object' ||
-    typeof data.attributes === 'object'
+    (data.attributes !== null && typeof data.attributes === 'object') ||
+    (data.keys !== null && typeof data.keys === 'object') ||
+    (data.relationships !== null && typeof data.relationships === 'object')
   );
 }
 

--- a/tests/integration/model-aware-normalizer-test.ts
+++ b/tests/integration/model-aware-normalizer-test.ts
@@ -1,0 +1,183 @@
+import { Store } from 'ember-orbit';
+import {
+  Planet,
+  Moon,
+  Star,
+  BinaryStar,
+  PlanetarySystem
+} from 'dummy/tests/support/dummy-models';
+import { createStore } from 'dummy/tests/support/store';
+import { module, test } from 'qunit';
+
+import { setupTest } from 'ember-qunit';
+import {
+  isStandardRecord,
+  ModelAwareNormalizer
+} from 'ember-orbit/-private/utils/model-aware-normalizer';
+
+module('Integration - ModelAwareNormalizer', function (hooks) {
+  setupTest(hooks);
+
+  let store: Store;
+  let normalizer: ModelAwareNormalizer;
+
+  hooks.beforeEach(function () {
+    store = createStore(this.owner, {
+      planet: Planet,
+      moon: Moon,
+      star: Star,
+      binaryStar: BinaryStar,
+      planetarySystem: PlanetarySystem
+    });
+    normalizer = store.transformBuilder.$normalizer as ModelAwareNormalizer;
+  });
+
+  test('isStandardRecord function checks whether a record is already in standard normalized form', function (assert) {
+    assert.ok(
+      isStandardRecord({
+        type: 'planet',
+        id: 'jupiter',
+        attributes: {
+          name: 'Jupiter'
+        }
+      })
+    );
+    assert.ok(
+      isStandardRecord({
+        type: 'planet',
+        id: 'jupiter',
+        keys: {
+          remoteId: '123'
+        }
+      })
+    );
+    assert.ok(
+      isStandardRecord({
+        type: 'planet',
+        id: 'jupiter',
+        relationships: {
+          sun: {
+            data: null
+          }
+        }
+      })
+    );
+    assert.notOk(
+      isStandardRecord({
+        type: 'planet',
+        id: 'jupiter',
+        name: 'Jupiter',
+        sun: null
+      })
+    );
+  });
+
+  test('#normalizeRecord', async function (assert) {
+    const callisto = await store.addRecord({
+      type: 'moon',
+      id: 'callisto',
+      name: 'Callisto'
+    });
+    const sun = await store.addRecord({
+      type: 'star',
+      id: 'sun',
+      name: 'The Sun'
+    });
+
+    const normalized = normalizer.normalizeRecord({
+      type: 'planet',
+      id: 'jupiter',
+      name: 'Jupiter',
+      moons: [callisto],
+      sun: sun
+    });
+
+    assert.strictEqual(normalized.id, 'jupiter', 'normalized id');
+    assert.strictEqual(normalized.type, 'planet', 'normalized type');
+    assert.deepEqual(normalized.keys, undefined, 'normalized keys');
+    assert.deepEqual(normalized.attributes, { name: 'Jupiter' });
+    assert.deepEqual(
+      normalized.relationships?.moons,
+      { data: [{ type: 'moon', id: 'callisto' }] },
+      'normalized hasMany'
+    );
+    assert.deepEqual(
+      normalized.relationships?.sun,
+      { data: { type: 'star', id: 'sun' } },
+      'normalized hasOne'
+    );
+  });
+
+  test('#normalizeRecord - polymorphic relationships', async function (assert) {
+    const luna = await store.addRecord({
+      type: 'moon',
+      id: 'luna',
+      name: 'Luna'
+    });
+    const earth = await store.addRecord({
+      type: 'planet',
+      id: 'earth',
+      name: 'Earth'
+    });
+    const sun = await store.addRecord({
+      type: 'star',
+      id: 'sun',
+      name: 'The Sun'
+    });
+
+    const expectedName = 'Our Solar System';
+    const normalized = normalizer.normalizeRecord({
+      type: 'planetarySystem',
+      id: 'homeSystem',
+      name: expectedName,
+      star: sun,
+      bodies: [luna, earth]
+    });
+
+    assert.strictEqual(normalized.id, 'homeSystem', 'normalized id');
+    assert.strictEqual(normalized.type, 'planetarySystem', 'normalized type');
+    assert.deepEqual(normalized.keys, undefined, 'normalized keys');
+    assert.deepEqual(normalized.attributes, { name: expectedName });
+    assert.deepEqual(
+      normalized.relationships?.star,
+      { data: { type: 'star', id: 'sun' } },
+      'normalized hasOne'
+    );
+    assert.deepEqual(
+      normalized.relationships?.bodies,
+      {
+        data: [
+          { type: 'moon', id: 'luna' },
+          { type: 'planet', id: 'earth' }
+        ]
+      },
+      'normalized hasMany'
+    );
+  });
+
+  test('#normalizeRecord - pre-normalized attributes + undefined relationships', function (assert) {
+    const normalized = normalizer.normalizeRecord({
+      type: 'planet',
+      id: 'jupiter',
+      attributes: {
+        name: 'Jupiter'
+      }
+    });
+
+    assert.deepEqual(normalized.attributes?.name, 'Jupiter');
+  });
+
+  test('#normalizeRecord - pre-normalized relationship + undefined attributes', function (assert) {
+    const normalized = normalizer.normalizeRecord({
+      type: 'planet',
+      id: 'jupiter',
+      relationships: {
+        sun: {
+          data: null
+        }
+      }
+    });
+
+    assert.deepEqual(normalized.relationships?.sun, { data: null });
+  });
+});


### PR DESCRIPTION
There was a typo in the `isStandardRecord` fn such that `.attributes` was checked twice while `.relationships` was not checked at all. This was causing errors for records which were added with _only_ relationships (and no keys or attributes).

Fixes #396