### PR TITLE
Allow for conditional creation of sources and strategies

### DIFF
--- a/addon/-private/factories/coordinator-factory.ts
+++ b/addon/-private/factories/coordinator-factory.ts
@@ -23,9 +23,9 @@ export default {
           modulesOfType(app.base.modulePrefix, orbitConfig.collections.sources);
         sourceNames.push('store');
       }
-      injections.sources = sourceNames.map((name) =>
-        app.lookup(`${orbitConfig.types.source}:${name}`)
-      );
+      injections.sources = sourceNames
+        .map((name) => app.lookup(`${orbitConfig.types.source}:${name}`))
+        .filter((source) => !!source);
     }
 
     if (injections.strategies === undefined) {
@@ -41,9 +41,9 @@ export default {
             orbitConfig.collections.strategies
           );
       }
-      injections.strategies = strategyNames.map((name) =>
-        app.lookup(`${orbitConfig.types.strategy}:${name}`)
-      );
+      injections.strategies = strategyNames
+        .map((name) => app.lookup(`${orbitConfig.types.strategy}:${name}`))
+        .filter((strategy) => !!strategy);
     }
 
     return new Coordinator(injections);

--- a/tests/dummy/app/data-sources/backup.js
+++ b/tests/dummy/app/data-sources/backup.js
@@ -1,0 +1,16 @@
+import { MemorySource } from '@orbit/memory';
+import { applyStandardSourceInjections } from 'ember-orbit';
+
+export default {
+  create(injections) {
+    applyStandardSourceInjections(injections);
+
+    // Note: An IndexedDBSource is typically used for data backups, since
+    // obviously a MemorySource does not persist its contents. This is only
+    // done as a simple demo that avoids an additional dependency.
+    return new MemorySource({
+      name: 'backup',
+      ...injections
+    });
+  }
+};

--- a/tests/dummy/app/data-strategies/event-logging.js
+++ b/tests/dummy/app/data-strategies/event-logging.js
@@ -1,0 +1,7 @@
+import { EventLoggingStrategy } from '@orbit/coordinator';
+
+export default {
+  create() {
+    return new EventLoggingStrategy();
+  }
+};

--- a/tests/dummy/app/data-strategies/store-backup-sync.js
+++ b/tests/dummy/app/data-strategies/store-backup-sync.js
@@ -1,0 +1,46 @@
+import { SyncStrategy } from '@orbit/coordinator';
+
+export default {
+  create() {
+    return new SyncStrategy({
+      name: 'store-backup-sync',
+
+      /**
+       * The name of the source which will have its `transform` event observed.
+       */
+      source: 'store',
+
+      /**
+       * The name of the source which will be acted upon.
+       *
+       * When the source receives the `transform` event, the `sync` method
+       * will be invoked on the target.
+       */
+      target: 'backup',
+
+      /**
+       * A handler for any errors thrown as a result of invoking `sync` on the
+       * target.
+       */
+      // catch(e) {},
+
+      /**
+       * A filter function that returns `true` if `sync` should be performed.
+       *
+       * `filter` will be invoked in the context of this strategy (and thus will
+       * have access to both `this.source` and `this.target`).
+       */
+      // filter(...args) {},
+
+      /**
+       * Should resolution of the target's `sync` block the completion of the
+       * source's `transform`?
+       *
+       * Can be specified as a boolean or a function which which will be
+       * invoked in the context of this strategy (and thus will have access to
+       * both `this.source` and `this.target`).
+       */
+      blocking: true
+    });
+  }
+};

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class FilteredRoute extends Route {
+  @service dataCoordinator;
+
+  async beforeModel() {
+    await this.dataCoordinator.activate();
+  }
+}

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -5,7 +5,7 @@ module.exports = function (environment) {
     modulePrefix: 'dummy',
     environment,
     rootURL: '/',
-    locationType: 'auto',
+    locationType: 'history',
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build


### PR DESCRIPTION
Source and strategy factories can now return `null` or `undefined` from `create()`, in which case they will be ignored by the coordinator factory that typically instantiates them. This allows for conditional creation based upon an env setting or other cue.