### PR TITLE
Improve conditional creation of sources and strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,6 +646,32 @@ version will start at `1`. This value should be bumped to a a higher number with
 each significant change that requires a schema migration. Migrations themselves
 must be handled in each individual source.
 
+### Conditionally include strategies and sources
+
+Sources and strategies may be conditionally included in your app's coordinator
+by customizing the default export of the source / strategy factory. A valid
+factory is an object with the interface `{ create: () => {} }`. If a valid
+factory is not the default export for your module, it will be ignored.
+
+For example, the following strategy will be conditionally included for all
+non-production builds:
+
+```js
+// app/data-strategies/event-logging.js
+
+import { EventLoggingStrategy } from '@orbit/coordinator';
+import config from 'example/config/environment';
+
+const factory = {
+  create() {
+    return new EventLoggingStrategy();
+  }
+};
+
+// Conditionally include this strategy
+export default config.environment !== 'production' ? factory : null;
+```
+
 #### Customizing validators
 
 Like Orbit itself, EO enables validators by default in all sources. EO provides

--- a/addon/-private/factories/coordinator-factory.ts
+++ b/addon/-private/factories/coordinator-factory.ts
@@ -7,6 +7,10 @@ type CoordinatorInjections = {
   strategyNames?: string[];
 } & CoordinatorOptions;
 
+function isFactory(f?: { create: () => {} }): boolean {
+  return typeof f === 'object' && typeof f?.create === 'function';
+}
+
 export default {
   create(injections: CoordinatorInjections = {}): Coordinator {
     const app = getOwner(injections);
@@ -24,7 +28,11 @@ export default {
         sourceNames.push('store');
       }
       injections.sources = sourceNames
-        .map((name) => app.lookup(`${orbitConfig.types.source}:${name}`))
+        .map((name) => {
+          const key = `${orbitConfig.types.source}:${name}`;
+          const factory = app.resolveRegistration(key);
+          return isFactory(factory) ? app.lookup(key) : undefined;
+        })
         .filter((source) => !!source);
     }
 
@@ -42,7 +50,11 @@ export default {
           );
       }
       injections.strategies = strategyNames
-        .map((name) => app.lookup(`${orbitConfig.types.strategy}:${name}`))
+        .map((name) => {
+          const key = `${orbitConfig.types.strategy}:${name}`;
+          const factory = app.resolveRegistration(key);
+          return isFactory(factory) ? app.lookup(key) : undefined;
+        })
         .filter((strategy) => !!strategy);
     }
 

--- a/tests/dummy/app/data-sources/null.js
+++ b/tests/dummy/app/data-sources/null.js
@@ -1,0 +1,2 @@
+// This source factory will be ignored since it does not take the shape `{ create: () => {} }`
+export default {};

--- a/tests/dummy/app/data-strategies/event-logging.js
+++ b/tests/dummy/app/data-strategies/event-logging.js
@@ -1,7 +1,11 @@
 import { EventLoggingStrategy } from '@orbit/coordinator';
+import config from 'dummy/config/environment';
 
-export default {
+const factory = {
   create() {
     return new EventLoggingStrategy();
   }
 };
+
+// Conditionally include this strategy
+export default config.environment !== 'production' ? factory : null;

--- a/tests/dummy/app/data-strategies/null.js
+++ b/tests/dummy/app/data-strategies/null.js
@@ -1,0 +1,2 @@
+// This strategy factory will be ignored since it does not take the shape `{ create: () => {} }`
+export default null;


### PR DESCRIPTION
This builds upon earlier work in #399 which allowed source and strategy factories to conditionally return `null` or `undefined` to signal that they should be ignored by the coordinator factory. The issue with this approach is that the returned value still ends up in the application's container, and non-objects are not handled properly when the container is destroyed. This could cause issues in test teardown for instance.

Instead of returning a custom value from `create`, it is now recommended that the default export of the source or strategy module be conditionally changed to a non-factory (e.g. `null` or `undefined`) to signal that it should be ignored. This avoids the call to `lookup` and thus prevents nullish values from entering the container. Documentation and an example have been added to the README.